### PR TITLE
Decrease transmit latency when using hardware triggered mode.

### DIFF
--- a/firmware/hackrf_usb/usb_api_transceiver.c
+++ b/firmware/hackrf_usb/usb_api_transceiver.c
@@ -234,6 +234,7 @@ usb_request_status_t usb_vendor_request_set_freq_explicit(
 
 static volatile transceiver_mode_t _transceiver_mode = TRANSCEIVER_MODE_OFF;
 static volatile hw_sync_mode_t _hw_sync_mode = HW_SYNC_MODE_OFF;
+static volatile bool _should_prepare_buffer_for_tx_or_rx = false;
 
 void set_hw_sync_mode(const hw_sync_mode_t new_hw_sync_mode) {
 	_hw_sync_mode = new_hw_sync_mode;
@@ -273,9 +274,15 @@ void set_transceiver_mode(const transceiver_mode_t new_transceiver_mode) {
 		activate_best_clock_source();
 
         hw_sync_enable(_hw_sync_mode);
-
-		baseband_streaming_enable(&sgpio_config);
 	}
+
+	_should_prepare_buffer_for_tx_or_rx = true;
+}
+
+bool should_prepare_buffer_for_tx_or_rx(void) {
+	bool ret = _should_prepare_buffer_for_tx_or_rx;
+	_should_prepare_buffer_for_tx_or_rx = false;
+	return ret;
 }
 
 usb_request_status_t usb_vendor_request_set_transceiver_mode(

--- a/firmware/hackrf_usb/usb_api_transceiver.h
+++ b/firmware/hackrf_usb/usb_api_transceiver.h
@@ -58,6 +58,6 @@ usb_request_status_t usb_vendor_request_set_hw_sync_mode(
 
 transceiver_mode_t transceiver_mode(void);
 void set_transceiver_mode(const transceiver_mode_t new_transceiver_mode);
-void start_streaming_on_hw_sync();
+bool should_prepare_buffer_for_tx_or_rx(void);
 
 #endif/*__USB_API_TRANSCEIVER_H__*/

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -434,7 +434,7 @@ int tx_callback(hackrf_transfer* transfer) {
 	if( fd != NULL )
 	{
 		byte_count += transfer->valid_length;
-		bytes_to_read = transfer->valid_length;
+		bytes_to_read = transfer->buffer_length;
 		if (limit_num_samples) {
 			if (bytes_to_read >= bytes_to_xfer) {
 				/*
@@ -465,7 +465,7 @@ int tx_callback(hackrf_transfer* transfer) {
 	} else if (transceiver_mode == TRANSCEIVER_MODE_SS) {
 		/* Transmit continuous wave with specific amplitude */
 		byte_count += transfer->valid_length;
-		bytes_to_read = transfer->valid_length;
+		bytes_to_read = transfer->buffer_length;
 		if (limit_num_samples) {
 			if (bytes_to_read >= bytes_to_xfer) {
 				bytes_to_read = bytes_to_xfer;

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -259,11 +259,39 @@ static int prepare_transfers(
 			device->transfers[transfer_index]->endpoint = endpoint_address;
 			device->transfers[transfer_index]->callback = callback;
 
-			error = libusb_submit_transfer(device->transfers[transfer_index]);
-			if( error != 0 )
-			{
-				last_libusb_error = error;
-				return HACKRF_ERROR_LIBUSB;
+			if ((endpoint_address & LIBUSB_ENDPOINT_OUT) == LIBUSB_ENDPOINT_OUT) {
+				// If we are transmitting then we fill the first buffers to be
+				// sent to the HackRF from the data callback as otherwise the
+				// HackRF will receive four transfers of zeros.
+				// For an OUT transfer `actual_length` will contain the number
+				// of bytes successfully transferred when the callback is made.
+				// It does not contain the size of the buffer to be filled.
+				// However, `valid_length` is commonly used in other HackRF
+				// code as the buffer length so we ensure that is the case here.
+				hackrf_transfer transfer = {
+					.device = device,
+					.buffer = device->transfers[transfer_index]->buffer,
+					.buffer_length = device->transfers[transfer_index]->length,
+					.valid_length = device->transfers[transfer_index]->length,
+					.rx_ctx = device->rx_ctx,
+					.tx_ctx = device->tx_ctx
+				};
+
+				if (device->callback(&transfer) == 0) {
+					error = libusb_submit_transfer(device->transfers[transfer_index]);
+					if (error != 0) {
+						last_libusb_error = error;
+						return HACKRF_ERROR_LIBUSB;
+					}
+				} else {
+					return HACKRF_ERROR_LIBUSB;
+				}
+			} else {
+				error = libusb_submit_transfer(device->transfers[transfer_index]);
+				if (error != 0) {
+					last_libusb_error = error;
+					return HACKRF_ERROR_LIBUSB;
+				}
 			}
 		}
 		return HACKRF_SUCCESS;
@@ -1507,6 +1535,15 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 			.tx_ctx = device->tx_ctx
 		};
 
+		// For an OUT transfer `actual_length` will contain the number of bytes
+		// successfully transferred when the callback is made. It does not
+		// contain the size of the buffer to be filled. However, `valid_length`
+		// is commonly used in other HackRF code as the buffer length so we
+		// ensure that is the case here.
+		if ((usb_transfer->endpoint & LIBUSB_ENDPOINT_OUT) == LIBUSB_ENDPOINT_OUT) {
+			transfer.valid_length = usb_transfer->length;
+		}
+
 		if( device->callback(&transfer) == 0 )
 		{
 			if( libusb_submit_transfer(usb_transfer) < 0)
@@ -1562,6 +1599,7 @@ static int create_transfer_thread(hackrf_device* device,
 	{
 		device->streaming = false;
 		device->do_exit = false;
+		device->callback = callback;
 
 		result = prepare_transfers(
 			device, endpoint_address,
@@ -1574,7 +1612,6 @@ static int create_transfer_thread(hackrf_device* device,
 		}
 
 		device->streaming = true;
-		device->callback = callback;
 		result = pthread_create(&device->transfer_thread, 0, transfer_threadproc, device);
 		if( result == 0 )
 		{

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -288,7 +288,7 @@ static int prepare_transfers(
 					.device = device,
 					.buffer = device->transfers[transfer_index]->buffer,
 					.buffer_length = device->transfers[transfer_index]->length,
-					.valid_length = device->transfers[transfer_index]->length,
+					.valid_length = device->transfers[transfer_index]->actual_length,
 					.rx_ctx = device->rx_ctx,
 					.tx_ctx = device->tx_ctx
 				};
@@ -1532,15 +1532,6 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 			.rx_ctx = device->rx_ctx,
 			.tx_ctx = device->tx_ctx
 		};
-
-		// For an OUT transfer `actual_length` will contain the number of bytes
-		// successfully transferred when the callback is made. It does not
-		// contain the size of the buffer to be filled. However, `valid_length`
-		// is commonly used in other HackRF code as the buffer length so we
-		// ensure that is the case here.
-		if ((usb_transfer->endpoint & LIBUSB_ENDPOINT_OUT) == LIBUSB_ENDPOINT_OUT) {
-			transfer.valid_length = usb_transfer->length;
-		}
 
 		if( device->callback(&transfer) == 0 )
 		{


### PR DESCRIPTION
Previously, when transmit was triggered, the HackRF would exhaust its SGPIO buffers followed by the first of its USB transfer buffer before requesting more data from the USB host. If the host was using `libhackrf` this would exhaust another four USB transfer buffers before sending samples provided by the transmit callback.

Now, we fill all these buffers with user-provided data as soon as possible so that when transmit is triggered the first sample transmitted is the first user provided sample.

We also reset the HackRF's USB transfer buffer when in receive mode so the first sample send over USB is the first sample received by the device.



┆Issue is synchronized with this [Basecamp todo](https://3.basecamp.com/5295633/buckets/26082705/todos/4597425394) by [Unito](https://www.unito.io)
