### PR TITLE
Drop streaming flag after cancelling all transfers

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -178,6 +178,7 @@ static int cancel_transfers(hackrf_device* device)
 				libusb_cancel_transfer(device->transfers[transfer_index]);
 			}
 		}
+		device->streaming = false;
 		return HACKRF_SUCCESS;
 	} else {
 		return HACKRF_ERROR_OTHER;


### PR DESCRIPTION
Otherwise transfer_tread_started is false, but streaming is still true. No big deal of course.



┆Issue is synchronized with this [Basecamp todo](https://3.basecamp.com/5295633/buckets/26082705/todos/4597439800) by [Unito](https://www.unito.io)
