### PR TITLE
Copy M0 image directly from ROM, instead of shadow region.

### DIFF
--- a/firmware/common/LPC43xx_M4_M0_image_from_text.ld
+++ b/firmware/common/LPC43xx_M4_M0_image_from_text.ld
@@ -22,7 +22,7 @@
 
 SECTIONS
 {
-	.text : {
+	.m0_text : {
 		PROVIDE(__m0_start__ = .);
 		KEEP(*(.m0_bin*));
 		. = ALIGN(4);


### PR DESCRIPTION
This changes m0_rom_to_ram to read directly from the ROM region, rather
than copying from where .text has been copied to RAM.

Previously the second .text section would be merged with the first one,
so the M0 image would be copied to RAM during `pre_main`. However, on
newer linkers the sections are not merged together so the second .text
section did not get copied to RAM.

fixes #936