### PR TITLE
Fix automatic rebuilding of M0 code

### DIFF
--- a/firmware/common/configure_file.cmake
+++ b/firmware/common/configure_file.cmake
@@ -1,0 +1,4 @@
+configure_file(
+    ${SRC}
+    ${DEST}
+)

--- a/firmware/common/m0_bin.s.cmake
+++ b/firmware/common/m0_bin.s.cmake
@@ -20,4 +20,4 @@
 	.data
 	.section	.m0_bin, "ax"
 	
-	.incbin		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_m0.bin"
+	.incbin		"${BIN}"

--- a/firmware/hackrf-common.cmake
+++ b/firmware/hackrf-common.cmake
@@ -117,9 +117,33 @@ include_directories("${LIBOPENCM3}/include/")
 include_directories("${PATH_HACKRF_FIRMWARE_COMMON}")
 
 macro(DeclareTarget project_name variant_suffix cflags ldflags)
-	add_library(${project_name}${variant_suffix}_objects OBJECT ${SRC_M4} m0_bin.s)
+	# Generate M0 bin from elf
+	add_custom_command(
+		OUTPUT ${project_name}${variant_suffix}_m0.bin
+		DEPENDS ${PROJECT_NAME}_m0.elf
+		COMMAND ${CMAKE_OBJCOPY} -Obinary ${PROJECT_NAME}_m0.elf ${project_name}${variant_suffix}_m0.bin
+	)
+
+	# Generate asm source that includes the M0 bin
+	add_custom_command(
+		OUTPUT ${project_name}${variant_suffix}_m0_bin.s
+		DEPENDS
+			${project_name}${variant_suffix}_m0.bin
+			${PATH_HACKRF_FIRMWARE_COMMON}/m0_bin.s.cmake
+			${PATH_HACKRF_FIRMWARE_COMMON}/configure_file.cmake
+		COMMAND
+			${CMAKE_COMMAND}
+			-DSRC=${PATH_HACKRF_FIRMWARE_COMMON}/m0_bin.s.cmake
+			-DDEST=${project_name}${variant_suffix}_m0_bin.s
+			-DBIN=${CMAKE_CURRENT_BINARY_DIR}/${project_name}${variant_suffix}_m0.bin
+			-P ${PATH_HACKRF_FIRMWARE_COMMON}/configure_file.cmake
+		# `configure_file` only updates the output if the input changed, but it can't recognise when the bin changes.
+		# So, force an update with `touch`
+		COMMAND ${CMAKE_COMMAND} -E touch ${project_name}${variant_suffix}_m0_bin.s
+	)
+
+	add_library(${project_name}${variant_suffix}_objects OBJECT ${SRC_M4} ${project_name}${variant_suffix}_m0_bin.s)
 	set_target_properties(${project_name}${variant_suffix}_objects PROPERTIES COMPILE_FLAGS "${cflags}")
-	add_dependencies(${project_name}${variant_suffix}_objects ${project_name}_m0.bin)
 	add_executable(${project_name}${variant_suffix}.elf $<TARGET_OBJECTS:${project_name}${variant_suffix}_objects>)
 	add_dependencies(${project_name}${variant_suffix}.elf libopencm3_${project_name})
 
@@ -176,11 +200,6 @@ macro(DeclareTargets)
 		)
 	endif()
 
-	configure_file(
-		${PATH_HACKRF_FIRMWARE_COMMON}/m0_bin.s.cmake
-		m0_bin.s
-	)
-
 	link_directories(
 		"${PATH_HACKRF_FIRMWARE_COMMON}"
 		"${LIBOPENCM3}/lib"
@@ -200,12 +219,6 @@ macro(DeclareTargets)
 
 	set_target_properties(${PROJECT_NAME}_m0.elf PROPERTIES COMPILE_FLAGS "${CFLAGS_M0}")
 	set_target_properties(${PROJECT_NAME}_m0.elf PROPERTIES LINK_FLAGS "${LDFLAGS_M0}")
-
-	add_custom_target(
-		${PROJECT_NAME}_m0.bin
-		DEPENDS ${PROJECT_NAME}_m0.elf
-		COMMAND ${CMAKE_OBJCOPY} -Obinary ${PROJECT_NAME}_m0.elf ${PROJECT_NAME}_m0.bin
-	)
 
 	DeclareTarget("${PROJECT_NAME}" "" "${CFLAGS_M4}" "${LDFLAGS_M4}")	
 	DeclareTarget("${PROJECT_NAME}" "_ram" "${CFLAGS_M4_RAM}" "${LDFLAGS_M4_RAM}")	


### PR DESCRIPTION
This uses `add_custom_command` to run a cmake script instead of using
`configure_file` directly, which allows for adding dependencies and
creates an ouput that can be depended on.

It also uses `add_custom_command` instead of `add_custom_target` to
create the M0 binary, since custom targets have no output file to depend
on.

Unfortunately, multiple targets cannot depend on the same generated file
or cmake tries to run the generation multiple times in parallel. So, the
.bin/.s generation is now duplicated for each target so they don't
conflict.

fixes #693