### PR TITLE
hackrf_sweep: simplify dwell time, bin width, and time stamps

### DIFF
--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -349,7 +349,7 @@ static void usage() {
 	fprintf(stderr, "\t[-p antenna_enable] # Antenna port power, 1=Enable, 0=Disable\n");
 	fprintf(stderr, "\t[-l gain_db] # RX LNA (IF) gain, 0-40dB, 8dB steps\n");
 	fprintf(stderr, "\t[-g gain_db] # RX VGA (baseband) gain, 0-62dB, 2dB steps\n");
-	fprintf(stderr, "\t[-w bin_width] # FFT bin width (frequency resolution) in Hz, 2444-5000000\n");
+	fprintf(stderr, "\t[-w bin_width] # FFT bin width (frequency resolution) in Hz, 2445-5000000\n");
 	fprintf(stderr, "\t[-1] # one shot mode\n");
 	fprintf(stderr, "\t[-N num_sweeps] # Number of sweeps to perform\n");
 	fprintf(stderr, "\t[-B] # binary output\n");
@@ -542,12 +542,15 @@ int main(int argc, char** argv) {
 
 	/*
 	 * The maximum number of FFT bins we support is equal to the number of
-	 * samples in a block. With our fixed sample rate of 20 Msps, that
-	 * results in a minimum bin width of 2444 Hz.
+	 * samples in a block. Each block consists of 16384 bytes minus 10
+	 * bytes for the frequency header, leaving room for 8187 two-byte
+	 * samples. As we pad fftSize up to the next odd multiple of four, this
+	 * makes our maximum supported fftSize 8180.  With our fixed sample
+	 * rate of 20 Msps, that results in a minimum bin width of 2445 Hz.
 	 */
-	if(8184 < fftSize) {
+	if(8180 < fftSize) {
 		fprintf(stderr,
-				"argument error: FFT bin width (-w) must be no less than 2444\n");
+				"argument error: FFT bin width (-w) must be no less than 2445\n");
 		return EXIT_FAILURE;
 	}
 

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -349,7 +349,7 @@ static void usage() {
 	fprintf(stderr, "\t[-p antenna_enable] # Antenna port power, 1=Enable, 0=Disable\n");
 	fprintf(stderr, "\t[-l gain_db] # RX LNA (IF) gain, 0-40dB, 8dB steps\n");
 	fprintf(stderr, "\t[-g gain_db] # RX VGA (baseband) gain, 0-62dB, 2dB steps\n");
-	fprintf(stderr, "\t[-w bin_width] # FFT bin width (frequency resolution) in Hz\n");
+	fprintf(stderr, "\t[-w bin_width] # FFT bin width (frequency resolution) in Hz, 2444-5000000\n");
 	fprintf(stderr, "\t[-1] # one shot mode\n");
 	fprintf(stderr, "\t[-N num_sweeps] # Number of sweeps to perform\n");
 	fprintf(stderr, "\t[-B] # binary output\n");
@@ -529,15 +529,25 @@ int main(int argc, char** argv) {
 		return EXIT_FAILURE;
 	}
 
+	/*
+	 * The FFT bin width must be no more than a quarter of the sample rate
+	 * for interleaved mode. With our fixed sample rate of 20 Msps, that
+	 * results in a maximum bin width of 5000000 Hz.
+	 */
 	if(4 > fftSize) {
 		fprintf(stderr,
-				"argument error: FFT bin width (-w) must be no more than one quarter the sample rate\n");
+				"argument error: FFT bin width (-w) must be no more than 5000000\n");
 		return EXIT_FAILURE;
 	}
 
+	/*
+	 * The maximum number of FFT bins we support is equal to the number of
+	 * samples in a block. With our fixed sample rate of 20 Msps, that
+	 * results in a minimum bin width of 2444 Hz.
+	 */
 	if(8184 < fftSize) {
 		fprintf(stderr,
-				"argument error: FFT bin width (-w) too small, resulted in more than 8184 FFT bins\n");
+				"argument error: FFT bin width (-w) must be no less than 2444\n");
 		return EXIT_FAILURE;
 	}
 

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -171,7 +171,6 @@ volatile uint64_t sweep_count = 0;
 
 struct timeval time_start;
 struct timeval t_start;
-struct timeval time_stamp;
 
 bool amp = false;
 uint32_t amp_enable;
@@ -257,14 +256,6 @@ int rx_callback(hackrf_transfer* transfer) {
 				}
 			}
 			sweep_started = true;
-			time_stamp = usb_transfer_time;
-			time_stamp.tv_usec +=
-					(uint64_t)(num_samples + THROWAWAY_BLOCKS * SAMPLES_PER_BLOCK)
-					* j * FREQ_ONE_MHZ / DEFAULT_SAMPLE_RATE_HZ;
-			if(999999 < time_stamp.tv_usec) {
-				time_stamp.tv_sec += time_stamp.tv_usec / 1000000;
-				time_stamp.tv_usec = time_stamp.tv_usec % 1000000;
-			}
 		}
 		if(do_exit) {
 			return 0;
@@ -320,12 +311,12 @@ int rx_callback(hackrf_transfer* transfer) {
 				ifftwIn[ifft_idx + i][1] = fftwOut[i + 1 + (fftSize/8)][1];
 			}
 		} else {
-			time_t time_stamp_seconds = time_stamp.tv_sec;
+			time_t time_stamp_seconds = usb_transfer_time.tv_sec;
 			fft_time = localtime(&time_stamp_seconds);
 			strftime(time_str, 50, "%Y-%m-%d, %H:%M:%S", fft_time);
 			fprintf(outfile, "%s.%06ld, %" PRIu64 ", %" PRIu64 ", %.2f, %u",
 					time_str,
-					(long int)time_stamp.tv_usec,
+					(long int)usb_transfer_time.tv_usec,
 					(uint64_t)(frequency),
 					(uint64_t)(frequency+DEFAULT_SAMPLE_RATE_HZ/4),
 					fft_bin_width,
@@ -336,7 +327,7 @@ int rx_callback(hackrf_transfer* transfer) {
 			fprintf(outfile, "\n");
 			fprintf(outfile, "%s.%06ld, %" PRIu64 ", %" PRIu64 ", %.2f, %u",
 					time_str,
-					(long int)time_stamp.tv_usec,
+					(long int)usb_transfer_time.tv_usec,
 					(uint64_t)(frequency+(DEFAULT_SAMPLE_RATE_HZ/2)),
 					(uint64_t)(frequency+((DEFAULT_SAMPLE_RATE_HZ*3)/4)),
 					fft_bin_width,


### PR DESCRIPTION
This removes support for longer dwell times at each frequency, something that I don't think has ever worked except perhaps in pre-release versions of hackrf_sweep.

fixes #865
fixes #951