### PR TITLE
add subdirectory builds to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,38 @@ jobs:
       shell: bash
       run: cmake --build . --config $BUILD_TYPE
 
+    - name: Create Build Environment (libhackrf)
+      run: cmake -E make_directory ${{runner.workspace}}/host/libhackrf/build
+
+    - name: Configure CMake (libhackrf)
+      shell: bash
+      working-directory: ${{runner.workspace}}/host/libhackrf/build
+      run: cmake $GITHUB_WORKSPACE/host/libhackrf/ -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Build (libhackrf)
+      working-directory: ${{runner.workspace}}/host/libhackrf/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE
+
+    - name: Install (libhackrf)
+      working-directory: ${{runner.workspace}}/host/libhackrf/build
+      shell: bash
+      run: |
+        sudo cmake --install . --config $BUILD_TYPE
+
+    - name: Create Build Environment (hackrf-tools)
+      run: cmake -E make_directory ${{runner.workspace}}/host/hackrf-tools/build
+
+    - name: Configure CMake (hackrf-tools)
+      shell: bash
+      working-directory: ${{runner.workspace}}/host/hackrf-tools/build
+      run: cmake $GITHUB_WORKSPACE/host/hackrf-tools/ -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Build (hackrf-tools)
+      working-directory: ${{runner.workspace}}/host/hackrf-tools/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE
+
   firmware:
     strategy:
       matrix:


### PR DESCRIPTION
Build in the libhackrf and hackrf-tools subdirectories in addition to the top host directory.