### PR TITLE
Fix double hyphen (--) rendered as en dash

### DIFF
--- a/docs/source/hackrf_one.rst
+++ b/docs/source/hackrf_one.rst
@@ -82,4 +82,4 @@ The CLKIN port on HackRF One is a high impedance input that expects a 0 V to 3 V
 
 HackRF One uses CLKIN instead of the internal crystal when a clock signal is detected on CLKIN. The switch to or from CLKIN only happens when a transmit or receive operation begins.
 
-To verify that a signal has been detected on CLKIN, use `hackrf_debug --si5351c -n 0 -r`. The expected output with a clock detected is `[ 0] -> 0x01`. The expected output with no clock detected is `[ 0] -> 0x51`.
+To verify that a signal has been detected on CLKIN, use ``hackrf_debug --si5351c -n 0 -r``. The expected output with a clock detected is `[ 0] -> 0x01`. The expected output with no clock detected is `[ 0] -> 0x51`.


### PR DESCRIPTION
Enclosed `hackrf_debug` tool invocation into double back quotes (``) so that when it's rendered to HTML double hyphen is not converted to en dash.