### PR TITLE
Fixes for concurrency bugs in start/stop operations

### DIFF
--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -263,15 +263,29 @@ int main(void) {
 	operacake_init(operacake_allow_gpio);
 
 	while(true) {
-		switch (transceiver_mode()) {
+
+		// Briefly disable USB interrupt so that we can
+		// atomically retrieve both the transceiver mode
+		// and the mode change sequence number. They are
+		// changed together by the set_transceiver_mode
+		// vendor request handler.
+
+		nvic_disable_irq(NVIC_USB0_IRQ);
+
+		transceiver_mode_t mode = transceiver_mode();
+		uint32_t seq = transceiver_mode_seq();
+
+		nvic_enable_irq(NVIC_USB0_IRQ);
+
+		switch (mode) {
 		case TRANSCEIVER_MODE_RX:
-			rx_mode();
+			rx_mode(seq);
 			break;
 		case TRANSCEIVER_MODE_TX:
-			tx_mode();
+			tx_mode(seq);
 			break;
 		case TRANSCEIVER_MODE_RX_SWEEP:
-			sweep_mode();
+			sweep_mode(seq);
 			break;
 		case TRANSCEIVER_MODE_CPLD_UPDATE:
 			cpld_update();

--- a/firmware/hackrf_usb/usb_api_sweep.c
+++ b/firmware/hackrf_usb/usb_api_sweep.c
@@ -87,7 +87,7 @@ usb_request_status_t usb_vendor_request_init_sweep(
 	return USB_REQUEST_STATUS_OK;
 }
 
-void sweep_mode(void) {
+void sweep_mode(uint32_t seq) {
 	unsigned int blocks_queued = 0;
 	unsigned int phase = 1;
 	bool odd = true;
@@ -98,7 +98,7 @@ void sweep_mode(void) {
 
 	baseband_streaming_enable(&sgpio_config);
 
-	while (TRANSCEIVER_MODE_RX_SWEEP == transceiver_mode()) {
+	while (transceiver_mode_seq() == seq) {
 		// Set up IN transfer of buffer 0.
 		if ( m0_state.offset >= 16384 && phase == 1) {
 			transfer = true;

--- a/firmware/hackrf_usb/usb_api_sweep.h
+++ b/firmware/hackrf_usb/usb_api_sweep.h
@@ -34,6 +34,6 @@ enum sweep_style {
 usb_request_status_t usb_vendor_request_init_sweep(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
 
-void sweep_mode(void);
+void sweep_mode(uint32_t seq);
 
 #endif /* __USB_API_SWEEP_H__ */

--- a/firmware/hackrf_usb/usb_api_transceiver.h
+++ b/firmware/hackrf_usb/usb_api_transceiver.h
@@ -57,9 +57,10 @@ usb_request_status_t usb_vendor_request_set_hw_sync_mode(
 	usb_endpoint_t* const endpoint,	const usb_transfer_stage_t stage);
 
 transceiver_mode_t transceiver_mode(void);
+uint32_t transceiver_mode_seq(void);
 void set_transceiver_mode(const transceiver_mode_t new_transceiver_mode);
 void start_streaming_on_hw_sync();
-void rx_mode(void);
-void tx_mode(void);
+void rx_mode(uint32_t seq);
+void tx_mode(uint32_t seq);
 
 #endif/*__USB_API_TRANSCEIVER_H__*/


### PR DESCRIPTION
Fixes bug #916.

Previously, there was a race which could lead to a transfer being left active after `cancel_transfers()` completed. This would then cause the next `prepare_transfers()` call to fail, because `libusb_submit_transfer()` would return an error due to the transfer already being in use.

The sequence of events that could cause this was:

1. Main thread calls `hackrf_stop_rx()`, which calls `cancel_transfers()`, which iterates through the 4 transfers in use and cancels them one by one with `libusb_cancel_transfer()`.
1. During this time, a transfer is completed. The transfer thread calls `hackrf_libusb_transfer_callback()`, which handles the data and then calls `libusb_submit_transfer()` to resubmit that transfer.
1. Now, `cancel_transfers()` and `hackrf_stop_rx()` are completed but one transfer is still active.
1. The next `hackrf_start_rx()` call fails, because `prepare_transfers()` tries to submit a transfer which is already in use.

To fix this, we add a lock which must be held to either cancel transfers or restart them. This ensures that only one of these actions can happen for a given transfer; it's no longer possible for a transfer to be cancelled and then immediately restarted.

With this change, I can now run the test program from #916 without failures.

