### PR TITLE
Add project mention for the APRS tracker

### DIFF
--- a/docs/source/software_support.rst
+++ b/docs/source/software_support.rst
@@ -33,6 +33,7 @@ QSpectrumAnalyzer - `https://github.com/xmikos/qspectrumanalyzer <https://github
 
 Spectrum Analyzer GUI for hackrf_sweep for Windows - `https://github.com/pavsa/hackrf-spectrum-analyzer <https://github.com/pavsa/hackrf-spectrum-analyzer>`__
 
+Web-based APRS tracker `https://xakcop.com/aprs-sdr <https://xakcop.com/aprs-sdr/>`__
 
 
 Can use HackRF data


### PR DESCRIPTION
APRS tracker which uses the HTML Geolocation API to retrieve the
device's position and WebUSB to communicate with the HackRF. The source
code is available at https://github.com/rgerganov/aprs-sdr