### PR TITLE
Move transceiver mode changes out of USB ISR.

### DIFF
--- a/firmware/hackrf_usb/usb_api_sweep.c
+++ b/firmware/hackrf_usb/usb_api_sweep.c
@@ -47,7 +47,7 @@ static uint32_t step_width = 0;
 static uint32_t offset = 0;
 static enum sweep_style style = LINEAR;
 
-/* Do this before starting sweep mode with set_transceiver_mode(). */
+/* Do this before starting sweep mode with request_transceiver_mode(). */
 usb_request_status_t usb_vendor_request_init_sweep(
 		usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
@@ -96,9 +96,11 @@ void sweep_mode(uint32_t seq) {
 	uint8_t *buffer;
 	bool transfer = false;
 
+	transceiver_startup(TRANSCEIVER_MODE_RX_SWEEP);
+
 	baseband_streaming_enable(&sgpio_config);
 
-	while (transceiver_mode_seq() == seq) {
+	while (transceiver_request.seq == seq) {
 		// Set up IN transfer of buffer 0.
 		if ( m0_state.offset >= 16384 && phase == 1) {
 			transfer = true;
@@ -165,4 +167,6 @@ void sweep_mode(uint32_t seq) {
 			blocks_queued = 0;
 		}
 	}
+
+	transceiver_shutdown();
 }

--- a/firmware/hackrf_usb/usb_api_transceiver.c
+++ b/firmware/hackrf_usb/usb_api_transceiver.c
@@ -251,6 +251,9 @@ volatile transceiver_request_t transceiver_request = {
 // Must be called from an atomic context (normally USB ISR)
 void request_transceiver_mode(transceiver_mode_t mode)
 {
+	usb_endpoint_flush(&usb_endpoint_bulk_in);
+	usb_endpoint_flush(&usb_endpoint_bulk_out);
+
 	transceiver_request.mode = mode;
 	transceiver_request.seq++;
 }

--- a/firmware/hackrf_usb/usb_api_transceiver.h
+++ b/firmware/hackrf_usb/usb_api_transceiver.h
@@ -27,6 +27,13 @@
 #include <usb_type.h>
 #include <usb_request.h>
 
+typedef struct {
+	transceiver_mode_t mode;
+	uint32_t seq;
+} transceiver_request_t;
+
+extern volatile transceiver_request_t transceiver_request;
+
 void set_hw_sync_mode(const hw_sync_mode_t new_hw_sync_mode);
 usb_request_status_t usb_vendor_request_set_transceiver_mode(
 	usb_endpoint_t* const endpoint,
@@ -56,11 +63,12 @@ usb_request_status_t usb_vendor_request_set_freq_explicit(
 usb_request_status_t usb_vendor_request_set_hw_sync_mode(
 	usb_endpoint_t* const endpoint,	const usb_transfer_stage_t stage);
 
-transceiver_mode_t transceiver_mode(void);
-uint32_t transceiver_mode_seq(void);
-void set_transceiver_mode(const transceiver_mode_t new_transceiver_mode);
+void request_transceiver_mode(transceiver_mode_t mode);
+void transceiver_startup(transceiver_mode_t mode);
+void transceiver_shutdown(void);
 void start_streaming_on_hw_sync();
 void rx_mode(uint32_t seq);
 void tx_mode(uint32_t seq);
+void off_mode(uint32_t seq);
 
 #endif/*__USB_API_TRANSCEIVER_H__*/


### PR DESCRIPTION
This is a defensive change to make the transceiver code easier to reason about, and to avoid the possibility of races such as that seen in #1042.

Previously, `set_transceiver_mode()` was called in the vendor request handler for the `SET_TRANSCEIVER_MODE` request, as well in the callback for a USB configuration change. Both these calls are made from the USB0 ISR, so could interrupt the `rx_mode()`, `tx_mode()` and `sweep_mode()` functions at any point. It was hard to tell if this was safe.

Instead, `set_transceiver_mode()` has been removed, and its work is split into three parts:

- `request_transceiver_mode()`, which is safe to call from ISR context. All this function does is update the requested mode and increment a sequence number. This builds on work already done in PR #1029, but the interface has been simplified to use a shared volatile structure.

- `transceiver_startup()`, which transitions the transceiver from an idle state to the configuration required for a specific mode, including setting up the RF path, configuring the M0, adjusting LEDs and UI etc.

- `transceiver_shutdown()`, which transitions the transceiver back to an idle state.

The `*_mode()` functions that implement the transceiver modes now call `transceiver_startup()` before starting work, and `transceiver_shutdown()` before returning, and all this happens in the main thread of execution.

As such, it is now guaranteed that all the steps involved happen in a consistent order, with the transceiver starting from an idle state, and being returned to an idle state before control returns to the main loop.

For consistency of interface, an `off_mode()` function has been added to implement the behaviour of the OFF transceiver mode. Since the transceiver is already guaranteed to be in an idle state when this is called, the only work required is to set the UI mode and wait for a new mode request.