### PR TITLE
Ensure fast exit

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1786,6 +1786,13 @@ static int kill_transfer_thread(hackrf_device* device)
 		 * Now call request_exit() to halt the main loop.
 		 */
 		request_exit(device);
+		/*
+		 * Make a final request, so that threadproc can exit immediately,
+		 * without waiting for timeout. Don't care about result.
+		 */
+		uint8_t board_id;
+		result = hackrf_board_id_read(device, &board_id);
+
 		value = NULL;
 		result = pthread_join(device->transfer_thread, &value);
 		if( result != 0 )

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1787,11 +1787,10 @@ static int kill_transfer_thread(hackrf_device* device)
 		 */
 		request_exit(device);
 		/*
-		 * Make a final request, so that threadproc can exit immediately,
-		 * without waiting for timeout. Don't care about result.
+		 * Interrupt the event handling thread instead of
+		 * waiting for timeout.
 		 */
-		uint8_t board_id;
-		result = hackrf_board_id_read(device, &board_id);
+		libusb_interrupt_event_handler(g_libusb_context);
 
 		value = NULL;
 		result = pthread_join(device->transfer_thread, &value);


### PR DESCRIPTION
transfer_threadproc has a timeout of half a second, so
when kill_transfer_thread tries to pthread_join, it often
has to wait until the timeout kicks in.

With this fix, we ensure that a final request is made after
request_exit has been called, so that transfer_threadproc can exit its
loop in a fast and clean manner.