### PR TITLE
Overhaul handling of transfer errors and use of streaming flag.

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -181,11 +181,6 @@ static int create_transfer_thread(hackrf_device* device);
 static libusb_context* g_libusb_context = NULL;
 int last_libusb_error = LIBUSB_SUCCESS;
 
-static void request_exit(hackrf_device* device)
-{
-	device->do_exit = true;
-}
-
 /*
  * Check if the transfers are setup and owned by libusb.
  *
@@ -1781,10 +1776,10 @@ static int kill_transfer_thread(hackrf_device* device)
 		 * thread has handled all completion callbacks.
 		 */
 		cancel_transfers(device);
-		/*
-		 * Now call request_exit() to halt the main loop.
-		 */
-		request_exit(device);
+
+		// Set flag to tell the thread to exit.
+		device->do_exit = true;
+
 		/*
 		 * Interrupt the event handling thread instead of
 		 * waiting for timeout.

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1704,6 +1704,9 @@ static void transfer_finished(struct hackrf_device* device, struct libusb_transf
 	int i;
 	bool all_finished = true;
 
+	// If a transfer finished for any reason, we're shutting down.
+	device->streaming = false;
+
 	for (i = 0; i < TRANSFER_COUNT; i++) {
 		if (device->transfers[i] == finished_transfer) {
 			device->transfer_finished[i] = true;
@@ -1754,22 +1757,18 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 
 			if (!resubmit || result < 0) {
 				transfer_finished(device, usb_transfer);
-				device->streaming = false;
 			}
 		} else {
 			transfer_finished(device, usb_transfer);
-			device->streaming = false;
 		}
 	} else if(usb_transfer->status == LIBUSB_TRANSFER_CANCELLED) {
 		transfer_finished(device, usb_transfer);
-		device->streaming = false;
 	} else {
 		/* Other cases LIBUSB_TRANSFER_NO_DEVICE
 		LIBUSB_TRANSFER_ERROR, LIBUSB_TRANSFER_TIMED_OUT
 		LIBUSB_TRANSFER_STALL,	LIBUSB_TRANSFER_OVERFLOW ....
 		*/
 		transfer_finished(device, usb_transfer);
-		device->streaming = false;
 	}
 }
 

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1754,6 +1754,7 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 
 			if (!resubmit || result < 0) {
 				transfer_finished(device, usb_transfer);
+				device->streaming = false;
 			}
 		} else {
 			transfer_finished(device, usb_transfer);

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1766,7 +1766,7 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 		LIBUSB_TRANSFER_ERROR, LIBUSB_TRANSFER_TIMED_OUT
 		LIBUSB_TRANSFER_STALL,	LIBUSB_TRANSFER_OVERFLOW ....
 		*/
-		request_exit(device); /* Fatal error stop transfer */
+		transfer_finished(device, usb_transfer);
 		device->streaming = false;
 	}
 }

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1831,6 +1831,8 @@ static int prepare_setup_transfers(hackrf_device* device,
 		return result;
 	}
 
+	device->streaming = true;
+
 	return HACKRF_SUCCESS;
 }
 
@@ -1894,9 +1896,6 @@ int ADDCALL hackrf_start_rx(hackrf_device* device, hackrf_sample_block_cb_fn cal
 	{
 		result = prepare_setup_transfers(device, endpoint_address, callback);
 	}
-	if (result == HACKRF_SUCCESS) {
-		device->streaming = true;
-	}
 	return result;
 }
 
@@ -1943,9 +1942,6 @@ int ADDCALL hackrf_start_tx(hackrf_device* device, hackrf_sample_block_cb_fn cal
 	{
 		device->tx_ctx = tx_ctx;
 		result = prepare_setup_transfers(device, endpoint_address, callback);
-	}
-	if (result == HACKRF_SUCCESS) {
-		device->streaming = true;
 	}
 	return result;
 }
@@ -2677,9 +2673,6 @@ int ADDCALL hackrf_start_rx_sweep(hackrf_device* device, hackrf_sample_block_cb_
 	{
 		device->rx_ctx = rx_ctx;
 		result = prepare_setup_transfers(device, endpoint_address, callback);
-	}
-	if (result == HACKRF_SUCCESS) {
-		device->streaming = true;
 	}
 	return result;
 }

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -351,6 +351,7 @@ static int prepare_transfers(
 			}
 		}
 		device->transfers_setup = true;
+		device->streaming = true;
 		return HACKRF_SUCCESS;
 	} else {
 		// This shouldn't happen.
@@ -1813,27 +1814,16 @@ static int prepare_setup_transfers(hackrf_device* device,
 	const uint8_t endpoint_address,
 		hackrf_sample_block_cb_fn callback)
 {
-	int result;
-
 	if( device->transfers_setup == true )
 	{
 		return HACKRF_ERROR_BUSY;
 	}
 
 	device->callback = callback;
-	result = prepare_transfers(
+	return prepare_transfers(
 		device, endpoint_address,
 		hackrf_libusb_transfer_callback
 	);
-
-	if( result != HACKRF_SUCCESS )
-	{
-		return result;
-	}
-
-	device->streaming = true;
-
-	return HACKRF_SUCCESS;
 }
 
 static int create_transfer_thread(hackrf_device* device)

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1762,6 +1762,7 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 		}
 	} else if(usb_transfer->status == LIBUSB_TRANSFER_CANCELLED) {
 		transfer_finished(device, usb_transfer);
+		device->streaming = false;
 	} else {
 		/* Other cases LIBUSB_TRANSFER_NO_DEVICE
 		LIBUSB_TRANSFER_ERROR, LIBUSB_TRANSFER_TIMED_OUT

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1737,7 +1737,7 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 			.tx_ctx = device->tx_ctx
 		};
 
-		if( device->callback(&transfer) == 0 )
+		if (device->streaming && device->callback(&transfer) == 0)
 		{
 			// Take lock to make sure that we don't restart a
 			// transfer whilst cancel_transfers() is in the middle

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -218,6 +218,9 @@ static int cancel_transfers(hackrf_device* device)
 	uint32_t transfer_index;
 	int i;
 
+	// If we're cancelling transfers for any reason, we're shutting down.
+	device->streaming = false;
+
 	if(transfers_check_setup(device) == true)
 	{
 		// Take lock while cancelling transfers. This blocks the
@@ -1922,7 +1925,6 @@ int ADDCALL hackrf_stop_rx(hackrf_device* device)
 {
 	int result;
 
-	device->streaming = false;
 	result = cancel_transfers(device);
 	if (result != HACKRF_SUCCESS)
 	{
@@ -1971,7 +1973,6 @@ static int hackrf_stop_tx_cmd(hackrf_device* device)
 int ADDCALL hackrf_stop_tx(hackrf_device* device)
 {
 	int result;
-	device->streaming = false;
 	result = cancel_transfers(device);
 	if (result != HACKRF_SUCCESS)
 	{

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1755,21 +1755,14 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 			// cancelled or restarted, not both.
 			pthread_mutex_unlock(&device->transfer_lock);
 
-			if (!resubmit || result < 0) {
-				transfer_finished(device, usb_transfer);
-			}
-		} else {
-			transfer_finished(device, usb_transfer);
+			if (resubmit && result == LIBUSB_SUCCESS)
+				return;
 		}
-	} else if(usb_transfer->status == LIBUSB_TRANSFER_CANCELLED) {
-		transfer_finished(device, usb_transfer);
-	} else {
-		/* Other cases LIBUSB_TRANSFER_NO_DEVICE
-		LIBUSB_TRANSFER_ERROR, LIBUSB_TRANSFER_TIMED_OUT
-		LIBUSB_TRANSFER_STALL,	LIBUSB_TRANSFER_OVERFLOW ....
-		*/
-		transfer_finished(device, usb_transfer);
 	}
+
+	// Unless we resubmitted this transfer and returned above,
+	// it's now finished.
+	transfer_finished(device, usb_transfer);
 }
 
 static int kill_transfer_thread(hackrf_device* device)


### PR DESCRIPTION
This PR ensures correct behaviour during shutdown, and reviews and simplifies usage of the `streaming` and `do_exit` flags. The changes are as follows:

- The transfer callback no longer calls `request_exit()` to end the transfer thread if an error occurs. It was no longer safe to do this after the changes in #1029, because we need the transfer thread to keep running, to handle cancellations and signal when these are complete. Instead, if it sees an error, the callback just records the transfer as finished, and clears the `streaming` flag. This fixes #1068.
- The transfer callback will no longer call the user RX callback, or submit further transfers, once the `streaming` flag is cleared. This ensures that:
  - Once the RX callback returns nonzero to indicate completion, it is not called again with further in-flight transfers.
  - After any libusb error occurs, no further RX callbacks are made and no more transfers are submitted.
- Review, correct and simplify all the cases where we set or clear `streaming` and `do_exit`. The result is:
  - The `streaming` flag is:
    - Set in `prepare_transfers`, which is called via `prepare_setup_transfers` by:
      - `hackrf_start_tx`
      - `hackrf_start_rx`
      - `hackrf_start_rx_sweep`
    - Cleared in `cancel_transfers`, which is called by:
      - `hackrf_stop_tx`
      - `hackrf_stop_rx`
      - `hackrf_close` via `kill_transfer_thread`
    - Cleared in `transfer_finished`, which is called by `hackrf_libusb_transfer_callback` if any transfer finishes without being successfully resubmitted.
    - Cleared in `transfer_threadproc` if `libusb_handle_events_timeout` returns an error.
  - The `do_exit` flag is set only in `kill_transfer_thread`, which is called only from `hackrf_close`. The flag is cleared again after joining the thread.