### PR TITLE
Remove unnecessary delays on stop, and duplicated stop commands on close.

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1947,22 +1947,20 @@ int ADDCALL hackrf_stop_tx(hackrf_device* device)
 
 int ADDCALL hackrf_close(hackrf_device* device)
 {
-	int result1, result2, result3;
+	int result1, result2;
 
 	result1 = HACKRF_SUCCESS;
 	result2 = HACKRF_SUCCESS;
-	result3 = HACKRF_SUCCESS;
 
 	if( device != NULL )
 	{
 		result1 = hackrf_stop_cmd(device);
-		result2 = hackrf_stop_cmd(device);
 
 		/*
 		 * Finally kill the transfer thread, which will
 		 * also cancel any pending transmit/receive transfers.
 		 */
-		result3 = kill_transfer_thread(device);
+		result2 = kill_transfer_thread(device);
 		if( device->usb_device != NULL )
 		{
 			libusb_release_interface(device->usb_device, 0);
@@ -1980,10 +1978,6 @@ int ADDCALL hackrf_close(hackrf_device* device)
 	}
 	open_devices--;
 
-	if (result3 != HACKRF_SUCCESS)
-	{
-		return result3;
-	}
 	if (result2 != HACKRF_SUCCESS)
 	{
 		return result2;

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1887,13 +1887,7 @@ int ADDCALL hackrf_start_rx(hackrf_device* device, hackrf_sample_block_cb_fn cal
 static int hackrf_stop_rx_cmd(hackrf_device* device)
 {
 	int result;
-
 	result = hackrf_set_transceiver_mode(device, HACKRF_TRANSCEIVER_MODE_OFF);
-#ifdef _WIN32
-	Sleep(10);
-#else
-	usleep(10 * 1000);
-#endif
 	return result;
 }
 
@@ -1935,11 +1929,6 @@ static int hackrf_stop_tx_cmd(hackrf_device* device)
 {
 	int result;
 	result = hackrf_set_transceiver_mode(device, HACKRF_TRANSCEIVER_MODE_OFF);
-#ifdef _WIN32
-	Sleep(10);
-#else
-	usleep(10 * 1000);
-#endif
 	return result;
 }
 

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -181,11 +181,6 @@ static int create_transfer_thread(hackrf_device* device);
 static libusb_context* g_libusb_context = NULL;
 int last_libusb_error = LIBUSB_SUCCESS;
 
-static void request_exit(hackrf_device* device)
-{
-	device->do_exit = true;
-}
-
 /*
  * Check if the transfers are setup and owned by libusb.
  *
@@ -1781,10 +1776,10 @@ static int kill_transfer_thread(hackrf_device* device)
 		 * thread has handled all completion callbacks.
 		 */
 		cancel_transfers(device);
-		/*
-		 * Now call request_exit() to halt the main loop.
-		 */
-		request_exit(device);
+
+		// Set flag to tell the thread to exit.
+		device->do_exit = true;
+
 		/*
 		 * Interrupt the event handling thread instead of
 		 * waiting for timeout.

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1704,6 +1704,9 @@ static void transfer_finished(struct hackrf_device* device, struct libusb_transf
 	int i;
 	bool all_finished = true;
 
+	// If a transfer finished for any reason, we're shutting down.
+	device->streaming = false;
+
 	for (i = 0; i < TRANSFER_COUNT; i++) {
 		if (device->transfers[i] == finished_transfer) {
 			device->transfer_finished[i] = true;
@@ -1754,22 +1757,18 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 
 			if (!resubmit || result < 0) {
 				transfer_finished(device, usb_transfer);
-				device->streaming = false;
 			}
 		} else {
 			transfer_finished(device, usb_transfer);
-			device->streaming = false;
 		}
 	} else if(usb_transfer->status == LIBUSB_TRANSFER_CANCELLED) {
 		transfer_finished(device, usb_transfer);
-		device->streaming = false;
 	} else {
 		/* Other cases LIBUSB_TRANSFER_NO_DEVICE
 		LIBUSB_TRANSFER_ERROR, LIBUSB_TRANSFER_TIMED_OUT
 		LIBUSB_TRANSFER_STALL,	LIBUSB_TRANSFER_OVERFLOW ....
 		*/
 		transfer_finished(device, usb_transfer);
-		device->streaming = false;
 	}
 }
 

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1884,7 +1884,7 @@ int ADDCALL hackrf_start_rx(hackrf_device* device, hackrf_sample_block_cb_fn cal
 	return result;
 }
 
-static int hackrf_stop_rx_cmd(hackrf_device* device)
+static int hackrf_stop_cmd(hackrf_device* device)
 {
 	int result;
 	result = hackrf_set_transceiver_mode(device, HACKRF_TRANSCEIVER_MODE_OFF);
@@ -1909,7 +1909,7 @@ int ADDCALL hackrf_stop_rx(hackrf_device* device)
 		return result;
 	}
 
-	return hackrf_stop_rx_cmd(device);
+	return hackrf_stop_cmd(device);
 }
 
 int ADDCALL hackrf_start_tx(hackrf_device* device, hackrf_sample_block_cb_fn callback, void* tx_ctx)
@@ -1922,13 +1922,6 @@ int ADDCALL hackrf_start_tx(hackrf_device* device, hackrf_sample_block_cb_fn cal
 		device->tx_ctx = tx_ctx;
 		result = prepare_setup_transfers(device, endpoint_address, callback);
 	}
-	return result;
-}
-
-static int hackrf_stop_tx_cmd(hackrf_device* device)
-{
-	int result;
-	result = hackrf_set_transceiver_mode(device, HACKRF_TRANSCEIVER_MODE_OFF);
 	return result;
 }
 
@@ -1949,7 +1942,7 @@ int ADDCALL hackrf_stop_tx(hackrf_device* device)
 		return result;
 	}
 
-	return hackrf_stop_tx_cmd(device);
+	return hackrf_stop_cmd(device);
 }
 
 int ADDCALL hackrf_close(hackrf_device* device)
@@ -1962,8 +1955,8 @@ int ADDCALL hackrf_close(hackrf_device* device)
 
 	if( device != NULL )
 	{
-		result1 = hackrf_stop_rx_cmd(device);
-		result2 = hackrf_stop_tx_cmd(device);
+		result1 = hackrf_stop_cmd(device);
+		result2 = hackrf_stop_cmd(device);
 
 		/*
 		 * Finally kill the transfer thread, which will

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1754,6 +1754,7 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 
 			if (!resubmit || result < 0) {
 				transfer_finished(device, usb_transfer);
+				device->streaming = false;
 			}
 		} else {
 			transfer_finished(device, usb_transfer);

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1766,7 +1766,7 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 		LIBUSB_TRANSFER_ERROR, LIBUSB_TRANSFER_TIMED_OUT
 		LIBUSB_TRANSFER_STALL,	LIBUSB_TRANSFER_OVERFLOW ....
 		*/
-		request_exit(device); /* Fatal error stop transfer */
+		transfer_finished(device, usb_transfer);
 		device->streaming = false;
 	}
 }

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1831,6 +1831,8 @@ static int prepare_setup_transfers(hackrf_device* device,
 		return result;
 	}
 
+	device->streaming = true;
+
 	return HACKRF_SUCCESS;
 }
 
@@ -1894,9 +1896,6 @@ int ADDCALL hackrf_start_rx(hackrf_device* device, hackrf_sample_block_cb_fn cal
 	{
 		result = prepare_setup_transfers(device, endpoint_address, callback);
 	}
-	if (result == HACKRF_SUCCESS) {
-		device->streaming = true;
-	}
 	return result;
 }
 
@@ -1943,9 +1942,6 @@ int ADDCALL hackrf_start_tx(hackrf_device* device, hackrf_sample_block_cb_fn cal
 	{
 		device->tx_ctx = tx_ctx;
 		result = prepare_setup_transfers(device, endpoint_address, callback);
-	}
-	if (result == HACKRF_SUCCESS) {
-		device->streaming = true;
 	}
 	return result;
 }
@@ -2677,9 +2673,6 @@ int ADDCALL hackrf_start_rx_sweep(hackrf_device* device, hackrf_sample_block_cb_
 	{
 		device->rx_ctx = rx_ctx;
 		result = prepare_setup_transfers(device, endpoint_address, callback);
-	}
-	if (result == HACKRF_SUCCESS) {
-		device->streaming = true;
 	}
 	return result;
 }

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -351,6 +351,7 @@ static int prepare_transfers(
 			}
 		}
 		device->transfers_setup = true;
+		device->streaming = true;
 		return HACKRF_SUCCESS;
 	} else {
 		// This shouldn't happen.
@@ -1813,27 +1814,16 @@ static int prepare_setup_transfers(hackrf_device* device,
 	const uint8_t endpoint_address,
 		hackrf_sample_block_cb_fn callback)
 {
-	int result;
-
 	if( device->transfers_setup == true )
 	{
 		return HACKRF_ERROR_BUSY;
 	}
 
 	device->callback = callback;
-	result = prepare_transfers(
+	return prepare_transfers(
 		device, endpoint_address,
 		hackrf_libusb_transfer_callback
 	);
-
-	if( result != HACKRF_SUCCESS )
-	{
-		return result;
-	}
-
-	device->streaming = true;
-
-	return HACKRF_SUCCESS;
 }
 
 static int create_transfer_thread(hackrf_device* device)

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1762,6 +1762,7 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 		}
 	} else if(usb_transfer->status == LIBUSB_TRANSFER_CANCELLED) {
 		transfer_finished(device, usb_transfer);
+		device->streaming = false;
 	} else {
 		/* Other cases LIBUSB_TRANSFER_NO_DEVICE
 		LIBUSB_TRANSFER_ERROR, LIBUSB_TRANSFER_TIMED_OUT

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1737,7 +1737,7 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 			.tx_ctx = device->tx_ctx
 		};
 
-		if( device->callback(&transfer) == 0 )
+		if (device->streaming && device->callback(&transfer) == 0)
 		{
 			// Take lock to make sure that we don't restart a
 			// transfer whilst cancel_transfers() is in the middle

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -218,6 +218,9 @@ static int cancel_transfers(hackrf_device* device)
 	uint32_t transfer_index;
 	int i;
 
+	// If we're cancelling transfers for any reason, we're shutting down.
+	device->streaming = false;
+
 	if(transfers_check_setup(device) == true)
 	{
 		// Take lock while cancelling transfers. This blocks the
@@ -1922,7 +1925,6 @@ int ADDCALL hackrf_stop_rx(hackrf_device* device)
 {
 	int result;
 
-	device->streaming = false;
 	result = cancel_transfers(device);
 	if (result != HACKRF_SUCCESS)
 	{
@@ -1971,7 +1973,6 @@ static int hackrf_stop_tx_cmd(hackrf_device* device)
 int ADDCALL hackrf_stop_tx(hackrf_device* device)
 {
 	int result;
-	device->streaming = false;
 	result = cancel_transfers(device);
 	if (result != HACKRF_SUCCESS)
 	{

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1755,21 +1755,14 @@ static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* 
 			// cancelled or restarted, not both.
 			pthread_mutex_unlock(&device->transfer_lock);
 
-			if (!resubmit || result < 0) {
-				transfer_finished(device, usb_transfer);
-			}
-		} else {
-			transfer_finished(device, usb_transfer);
+			if (resubmit && result == LIBUSB_SUCCESS)
+				return;
 		}
-	} else if(usb_transfer->status == LIBUSB_TRANSFER_CANCELLED) {
-		transfer_finished(device, usb_transfer);
-	} else {
-		/* Other cases LIBUSB_TRANSFER_NO_DEVICE
-		LIBUSB_TRANSFER_ERROR, LIBUSB_TRANSFER_TIMED_OUT
-		LIBUSB_TRANSFER_STALL,	LIBUSB_TRANSFER_OVERFLOW ....
-		*/
-		transfer_finished(device, usb_transfer);
 	}
+
+	// Unless we resubmitted this transfer and returned above,
+	// it's now finished.
+	transfer_finished(device, usb_transfer);
 }
 
 static int kill_transfer_thread(hackrf_device* device)


### PR DESCRIPTION
This is stacked on #1069 to avoid conflicts, so until that's merged, start reviewing from commit [`958c742`](https://github.com/greatscottgadgets/hackrf/pull/1070/commits/958c7421890c62436e198547473ccfcd3d838c46).

The changes in this PR are:

- Remove the 10ms delays that were added to `hackrf_stop_rx_cmd` and `hackrf_stop_tx_cmd` in PR #805.
  - These delays were a workaround to ensure that their calling functions did not return until transfer cancellations had completed. That problem is now fixed properly in #1029, so the delays are no longer necessary.
- Merge `hackrf_stop_rx_cmd` and `hackrf_stop_tx_cmd`, since they do the same thing: set transceiver mode to OFF.
- Remove the duplicate use of that command in `hackrf_close`.

