### PR TITLE
Simplify logic for tracking finished transfers

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1695,14 +1695,14 @@ static void transfer_finished(struct hackrf_device* device, struct libusb_transf
 	device->streaming = false;
 
 	// If this is the last transfer, signal that all are now finished.
+	pthread_mutex_lock(&device->all_finished_lock);
 	if (device->active_transfers == 1) {
-		pthread_mutex_lock(&device->all_finished_lock);
 		device->active_transfers = 0;
 		pthread_cond_signal(&device->all_finished_cv);
-		pthread_mutex_unlock(&device->all_finished_lock);
 	} else {
 		device->active_transfers--;
 	}
+	pthread_mutex_unlock(&device->all_finished_lock);
 }
 
 static void LIBUSB_CALL hackrf_libusb_transfer_callback(struct libusb_transfer* usb_transfer)


### PR DESCRIPTION
This is a followup cleanup to #1029.

This PR simplifies the logic for tracking finished transfers, by removing the per-transfer `transfer_finished` flags and the overall `all_finished` flag, and replacing them with a count of `active_transfers`. 

From a concurrency point of view everything works as before, except that the pthread condition variable is now associated with the assertion `active_transfers == 0` rather than `all_finished`. The associated lock must therefore be held to decrement that count to zero, and the condition is signalled when this happens.

I proposed this simplification in [this comment](https://github.com/greatscottgadgets/hackrf/pull/1029#issuecomment-1019592611) on PR #1029, but left it out of that PR in order to get a working fix merged ASAP.