### PR TITLE
Fix USB requests that were responding with data from the stack.

### DIFF
--- a/firmware/hackrf_usb/usb_api_board_info.c
+++ b/firmware/hackrf_usb/usb_api_board_info.c
@@ -56,11 +56,11 @@ usb_request_status_t usb_vendor_request_read_version_string(
 	return USB_REQUEST_STATUS_OK;
 }
 
+static read_partid_serialno_t read_partid_serialno;
 usb_request_status_t usb_vendor_request_read_partid_serialno(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
 	uint8_t length;
-	read_partid_serialno_t read_partid_serialno;
 	iap_cmd_res_t iap_cmd_res;
 
 	if (stage == USB_TRANSFER_STAGE_SETUP) 

--- a/firmware/hackrf_usb/usb_api_cpld.c
+++ b/firmware/hackrf_usb/usb_api_cpld.c
@@ -32,6 +32,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 
 uint8_t cpld_xsvf_buffer[512];
 volatile bool cpld_wait = false;
@@ -98,7 +99,8 @@ usb_request_status_t usb_vendor_request_cpld_checksum(
 		}
 		
 		length = (uint8_t)sizeof(cpld_crc);
-		usb_transfer_schedule_block(endpoint->in, &cpld_crc, length,
+		memcpy(endpoint->buffer, &cpld_crc, length);
+		usb_transfer_schedule_block(endpoint->in, endpoint->buffer, length,
 					    NULL, NULL);
 		usb_transfer_schedule_ack(endpoint->out);
 	}

--- a/firmware/hackrf_usb/usb_api_operacake.c
+++ b/firmware/hackrf_usb/usb_api_operacake.c
@@ -31,9 +31,8 @@ usb_request_status_t usb_vendor_request_operacake_get_boards(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
-		uint8_t addresses[8];
-		operacake_get_boards(addresses);
-		usb_transfer_schedule_block(endpoint->in, addresses, 8, NULL, NULL);
+		operacake_get_boards(endpoint->buffer);
+		usb_transfer_schedule_block(endpoint->in, endpoint->buffer, 8, NULL, NULL);
 		usb_transfer_schedule_ack(endpoint->out);
 	}
 	return USB_REQUEST_STATUS_OK;

--- a/firmware/hackrf_usb/usb_api_spiflash.c
+++ b/firmware/hackrf_usb/usb_api_spiflash.c
@@ -124,10 +124,9 @@ usb_request_status_t usb_vendor_request_read_spiflash(
 usb_request_status_t usb_vendor_request_spiflash_status(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
-	uint8_t data[2];
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
-		w25q80bv_get_full_status(&spi_flash, data);
-		usb_transfer_schedule_block(endpoint->in, &data, 2, NULL, NULL);
+		w25q80bv_get_full_status(&spi_flash, endpoint->buffer);
+		usb_transfer_schedule_block(endpoint->in, &endpoint->buffer, 2, NULL, NULL);
 		return USB_REQUEST_STATUS_OK;
 	} else if (stage == USB_TRANSFER_STAGE_DATA) {
 		usb_transfer_schedule_ack(endpoint->out);


### PR DESCRIPTION
After a passing comment from @miek some time ago, I had it on my todo list to check all the USB vendor request handlers for this problem.

Four of them were scheduling responses from locals on the stack, which could be overwritten by the time the host polls the device for the response.

This PR fixes that by putting their data in the endpoint buffer instead, or in another persistent location if that buffer is too small.