### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/technical-support.md
+++ b/.github/ISSUE_TEMPLATE/technical-support.md
@@ -1,0 +1,32 @@
+---
+name: Technical Support
+about: If you need technical support with your HackRF, use this template.
+title: ''
+labels: technical support
+assignees: ''
+
+---
+
+### Steps to reproduce
+1.
+2.
+3.
+
+### Expected behaviour
+Tell us what you expect should happen
+
+### Actual behaviour
+Tell us what happens instead
+
+### Version information
+**Operating system**:
+
+**hackrf_info output:**
+
+If you are reporting a problem that involves third party software 
+(GNU Radio, Gqrx, etc), please report the version here.
+
+### Output
+```
+Insert any commandline or build output here
+```


### PR DESCRIPTION
Uses the new GitHub "issue template" feature which pulls templates from the .github folder rather than the main code folder. 

GitHub notes on this feature: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates

If we like this feature I will add more templates. 