### PR TITLE
Interrupt driven transfers

### DIFF
--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -250,7 +250,7 @@ int main(void) {
 	usb_endpoint_init(&usb_endpoint_control_out);
 	usb_endpoint_init(&usb_endpoint_control_in);
 	
-	nvic_set_priority(NVIC_USB0_IRQ, 255);
+	nvic_set_priority(NVIC_USB0_IRQ, 192);
 
 	hackrf_ui()->init();
 

--- a/firmware/hackrf_usb/usb_api_m0_state.h
+++ b/firmware/hackrf_usb/usb_api_m0_state.h
@@ -38,6 +38,7 @@ struct m0_state {
 	uint32_t threshold;
 	uint32_t next_mode;
 	uint32_t error;
+	uint32_t transfer_size;
 };
 
 enum m0_mode {

--- a/firmware/hackrf_usb/usb_api_transceiver.c
+++ b/firmware/hackrf_usb/usb_api_transceiver.c
@@ -307,7 +307,7 @@ void transceiver_startup(const transceiver_mode_t mode) {
 	}
 
 	usb_count = 0;
-	nvic_set_priority(NVIC_M0CORE_IRQ, 192);
+	nvic_set_priority(NVIC_M0CORE_IRQ, 224);
 	nvic_enable_irq(NVIC_M0CORE_IRQ);
 
 	activate_best_clock_source();

--- a/firmware/hackrf_usb/usb_api_transceiver.c
+++ b/firmware/hackrf_usb/usb_api_transceiver.c
@@ -44,6 +44,8 @@
 #include "usb_endpoint.h"
 #include "usb_api_sweep.h"
 
+#define USB_TRANSFER_SIZE 0x4000
+
 typedef struct {
 	uint32_t freq_mhz;
 	uint32_t freq_hz;
@@ -375,15 +377,15 @@ void rx_mode(uint32_t seq) {
 	baseband_streaming_enable(&sgpio_config);
 
 	while (transceiver_request.seq == seq) {
-		if ((m0_state.m0_count - usb_count) >= 0x4000) {
+		if ((m0_state.m0_count - usb_count) >= USB_TRANSFER_SIZE) {
 			usb_transfer_schedule_block(
 				&usb_endpoint_bulk_in,
 				&usb_bulk_buffer[usb_count & USB_BULK_BUFFER_MASK],
-				0x4000,
+				USB_TRANSFER_SIZE,
 				transceiver_bulk_transfer_complete,
 				NULL
 				);
-			usb_count += 0x4000;
+			usb_count += USB_TRANSFER_SIZE;
 		}
 	}
 
@@ -399,11 +401,11 @@ void tx_mode(uint32_t seq) {
 	usb_transfer_schedule_block(
 		&usb_endpoint_bulk_out,
 		&usb_bulk_buffer[0x0000],
-		0x4000,
+		USB_TRANSFER_SIZE,
 		transceiver_bulk_transfer_complete,
 		NULL
 		);
-	usb_count += 0x4000;
+	usb_count += USB_TRANSFER_SIZE;
 
 	// Enable streaming. The M0 is in TX_START mode, and will automatically
 	// send zeroes until the host fills buffer 0. Once that buffer is filled,
@@ -412,15 +414,15 @@ void tx_mode(uint32_t seq) {
 	baseband_streaming_enable(&sgpio_config);
 
 	while (transceiver_request.seq == seq) {
-		if ((usb_count - m0_state.m0_count) <= 0x4000) {
+		if ((usb_count - m0_state.m0_count) <= USB_TRANSFER_SIZE) {
 			usb_transfer_schedule_block(
 				&usb_endpoint_bulk_out,
 				&usb_bulk_buffer[usb_count & USB_BULK_BUFFER_MASK],
-				0x4000,
+				USB_TRANSFER_SIZE,
 				transceiver_bulk_transfer_complete,
 				NULL
 				);
-			usb_count += 0x4000;
+			usb_count += USB_TRANSFER_SIZE;
 		}
 	}
 


### PR DESCRIPTION
This is an idea for how to make the USB transfer scheduling in RX and TX modes be interrupt-driven, freeing up the main thread for UI update or other functionality.

This requires telling the M0 core about the transfer size, and having it use the `SEV` instruction to interrupt the M4 whenever the byte count reaches a transfer boundary. This adds 6 cycles to the normal RX path but is still within limits.

This doesn't currently work, probably because `usb_transfer_schedule_block` isn't safe to call from an interrupt context. Setting an LED in the ISR indicates that it is being called, though.