### PR TITLE
Support repeating short files in `hackrf_transfer`

### DIFF
--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -533,15 +533,15 @@ int tx_callback(hackrf_transfer* transfer)
 		return 0;
 	}
 
-	if (repeat) {
-		fprintf(stderr, "Input file end reached. Rewind to beginning.\n");
-		rewind(file);
-		fread(transfer->buffer + bytes_read, 1, bytes_to_read - bytes_read, file);
-		return 0;
-	} else {
+	if (!repeat) {
 		stop_main_loop();
 		return -1; /* not repeat mode, end of file */
 	}
+
+	fprintf(stderr, "Input file end reached. Rewind to beginning.\n");
+	rewind(file);
+	fread(transfer->buffer + bytes_read, 1, bytes_to_read - bytes_read, file);
+	return 0;
 }
 
 static int update_stats(hackrf_device* device, hackrf_m0_state* state, stats_t* stats)

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -539,7 +539,6 @@ int tx_callback(hackrf_transfer* transfer)
 	}
 
 	while (bytes_read < bytes_to_read) {
-		fprintf(stderr, "Input file end reached. Rewind to beginning.\n");
 		rewind(file);
 		bytes_read +=
 			fread(transfer->buffer + bytes_read,

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -538,9 +538,16 @@ int tx_callback(hackrf_transfer* transfer)
 		return -1; /* not repeat mode, end of file */
 	}
 
-	fprintf(stderr, "Input file end reached. Rewind to beginning.\n");
-	rewind(file);
-	fread(transfer->buffer + bytes_read, 1, bytes_to_read - bytes_read, file);
+	while (bytes_read < bytes_to_read) {
+		fprintf(stderr, "Input file end reached. Rewind to beginning.\n");
+		rewind(file);
+		bytes_read +=
+			fread(transfer->buffer + bytes_read,
+			      1,
+			      bytes_to_read - bytes_read,
+			      file);
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
This PR fixes repeated transmission of short sample files using `hackrf_transfer`:

- The first three commits simplify the TX and RX callbacks, by using early returns rather than deeply indented conditional blocks. There should be no functional change from these commits.

- The main change is in https://github.com/greatscottgadgets/hackrf/pull/1132/commits/0c35cff05b061afae12b804fffb37e51bfbc9835, which adds a loop which repeatedly rewinds the file until the transfer buffer is filled.

- Finally the message `Input file end reached. Rewind to beginning` is removed, because with short input files it can be printed an extremely large number of times.

Closes #720.