### PR TITLE
Overhaul timing in hackrf_transfer

### DIFF
--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -609,7 +609,7 @@ static void usage()
 
 static hackrf_device* device = NULL;
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 BOOL WINAPI sighandler(int signum)
 {
 	if (CTRL_C_EVENT == signum) {
@@ -1041,7 +1041,7 @@ int main(int argc, char** argv)
 		fwrite(&wave_file_hdr, 1, sizeof(t_wav_file_hdr), file);
 	}
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 	SetConsoleCtrlHandler((PHANDLER_ROUTINE) sighandler, TRUE);
 #else
 	signal(SIGINT, &sigint_callback_handler);


### PR DESCRIPTION
Rather than using `sleep` for 1s at a time, set up an interval timer that will fire once per second, and wait in the main loop for either this or some other event.

On POSIX, the timing is set up with `setitimer`, which generates a `SIGALRM` signal each time the timer fires. The main loop runs `pause` to wait for any signal.

On Windows, the timing is set up using `CreateWaitableTimer`, which provides an event handle that is set each time the timer fires. The main loop runs `WaitForMultipleObjects` to wait on this and an interrupt event.

The TX and RX callbacks can now stop the main loop immediately when they stop streaming. This fixes #1019.