### PR TITLE
Add a simpler way to check CLKIN status.

### DIFF
--- a/docs/source/external_clock_interface.rst
+++ b/docs/source/external_clock_interface.rst
@@ -8,4 +8,4 @@ The CLKIN port on HackRF One is a high impedance input that expects a 0 V to 3 V
 
 HackRF One uses CLKIN instead of the internal crystal when a clock signal is detected on CLKIN. The switch to or from CLKIN only happens when a transmit or receive operation begins.
 
-To verify that a signal has been detected on CLKIN, use ``hackrf_debug --si5351c -n 0 -r``. The expected output with a clock detected is `[ 0] -> 0x01`. The expected output with no clock detected is `[ 0] -> 0x51`.
+To verify that a signal has been detected on CLKIN, use ``hackrf_clock -i``. The expected output with a clock detected is `CLKIN status: clock signal detected`. The expected output with no clock detected is `CLKIN status: no clock signal detected`.

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -118,6 +118,7 @@ static usb_request_handler_fn vendor_request_handler[] = {
 	usb_vendor_request_get_m0_state,
 	usb_vendor_request_set_tx_underrun_limit,
 	usb_vendor_request_set_rx_overrun_limit,
+	usb_vendor_request_get_clkin_status,
 };
 
 static const uint32_t vendor_request_handler_count =

--- a/firmware/hackrf_usb/usb_api_register.c
+++ b/firmware/hackrf_usb/usb_api_register.c
@@ -179,3 +179,20 @@ usb_request_status_t usb_vendor_request_set_clkout_enable(
 	}
 	return USB_REQUEST_STATUS_OK;
 }
+
+usb_request_status_t usb_vendor_request_get_clkin_status(
+	usb_endpoint_t* const endpoint,
+	const usb_transfer_stage_t stage)
+{
+	if (stage == USB_TRANSFER_STAGE_SETUP) {
+		endpoint->buffer[0] = si5351c_clkin_signal_valid(&clock_gen);
+		usb_transfer_schedule_block(
+			endpoint->in,
+			&endpoint->buffer,
+			1,
+			NULL,
+			NULL);
+		usb_transfer_schedule_ack(endpoint->out);
+	}
+	return USB_REQUEST_STATUS_OK;
+}

--- a/firmware/hackrf_usb/usb_api_register.h
+++ b/firmware/hackrf_usb/usb_api_register.h
@@ -47,5 +47,8 @@ usb_request_status_t usb_vendor_request_read_rffc5071(
 usb_request_status_t usb_vendor_request_set_clkout_enable(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage);
+usb_request_status_t usb_vendor_request_get_clkin_status(
+	usb_endpoint_t* const endpoint,
+	const usb_transfer_stage_t stage);
 
 #endif /* end of include guard: __USB_API_REGISTER_H__ */

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -99,6 +99,7 @@ typedef enum {
 	HACKRF_VENDOR_REQUEST_GET_M0_STATE = 41,
 	HACKRF_VENDOR_REQUEST_SET_TX_UNDERRUN_LIMIT = 42,
 	HACKRF_VENDOR_REQUEST_SET_RX_OVERRUN_LIMIT = 43,
+	HACKRF_VENDOR_REQUEST_GET_CLKIN_STATUS = 44,
 } hackrf_vendor_request;
 
 #define USB_CONFIG_STANDARD 0x1
@@ -2514,6 +2515,27 @@ int ADDCALL hackrf_set_clkout_enable(hackrf_device* device, const uint8_t value)
 		0);
 
 	if (result != 0) {
+		last_libusb_error = result;
+		return HACKRF_ERROR_LIBUSB;
+	} else {
+		return HACKRF_SUCCESS;
+	}
+}
+
+int ADDCALL hackrf_get_clkin_status(hackrf_device* device, uint8_t* status)
+{
+	USB_API_REQUIRED(device, 0x0106)
+	int result;
+	result = libusb_control_transfer(
+		device->usb_device,
+		LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE,
+		HACKRF_VENDOR_REQUEST_GET_CLKIN_STATUS,
+		0,
+		0,
+		status,
+		1,
+		0);
+	if (result < 1) {
 		last_libusb_error = result;
 		return HACKRF_ERROR_LIBUSB;
 	} else {

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -440,6 +440,8 @@ extern ADDAPI int ADDCALL hackrf_set_clkout_enable(
 	hackrf_device* device,
 	const uint8_t value);
 
+extern ADDAPI int ADDCALL hackrf_get_clkin_status(hackrf_device* device, uint8_t* status);
+
 extern ADDAPI int ADDCALL hackrf_operacake_gpio_test(
 	hackrf_device* device,
 	uint8_t address,


### PR DESCRIPTION
Add a new `hackrf_clock` option (`-i` or `--clkin`) which reports the CLKIN status, and doesn't require remembering cryptic Si5351 register values.