### PR TITLE
Preload TX transfers

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -104,6 +104,9 @@ typedef enum {
 
 #define USB_CONFIG_STANDARD 0x1
 
+#define RX_ENDPOINT_ADDRESS (LIBUSB_ENDPOINT_IN | 1)
+#define TX_ENDPOINT_ADDRESS (LIBUSB_ENDPOINT_OUT | 2)
+
 typedef enum {
 	HACKRF_TRANSCEIVER_MODE_OFF = 0,
 	HACKRF_TRANSCEIVER_MODE_RECEIVE = 1,
@@ -1239,7 +1242,7 @@ int ADDCALL hackrf_cpld_write(
 	for (i = 0; i < total_length; i += chunk_size) {
 		result = libusb_bulk_transfer(
 			device->usb_device,
-			LIBUSB_ENDPOINT_OUT | 2,
+			TX_ENDPOINT_ADDRESS,
 			&data[i],
 			chunk_size,
 			&transferred,
@@ -1847,7 +1850,7 @@ int ADDCALL hackrf_start_rx(
 	void* rx_ctx)
 {
 	int result;
-	const uint8_t endpoint_address = LIBUSB_ENDPOINT_IN | 1;
+	const uint8_t endpoint_address = RX_ENDPOINT_ADDRESS;
 	device->rx_ctx = rx_ctx;
 	result = hackrf_set_transceiver_mode(device, HACKRF_TRANSCEIVER_MODE_RECEIVE);
 	if (result == HACKRF_SUCCESS) {
@@ -1889,7 +1892,7 @@ int ADDCALL hackrf_start_tx(
 	void* tx_ctx)
 {
 	int result;
-	const uint8_t endpoint_address = LIBUSB_ENDPOINT_OUT | 2;
+	const uint8_t endpoint_address = TX_ENDPOINT_ADDRESS;
 	result = hackrf_set_transceiver_mode(device, HACKRF_TRANSCEIVER_MODE_TRANSMIT);
 	if (result == HACKRF_SUCCESS) {
 		device->tx_ctx = tx_ctx;
@@ -2631,7 +2634,7 @@ int ADDCALL hackrf_start_rx_sweep(
 {
 	USB_API_REQUIRED(device, 0x0104)
 	int result;
-	const uint8_t endpoint_address = LIBUSB_ENDPOINT_IN | 1;
+	const uint8_t endpoint_address = RX_ENDPOINT_ADDRESS;
 	result = hackrf_set_transceiver_mode(device, TRANSCEIVER_MODE_RX_SWEEP);
 	if (HACKRF_SUCCESS == result) {
 		device->rx_ctx = rx_ctx;

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -322,26 +322,26 @@ static int prepare_transfers(
 {
 	int error;
 	uint32_t transfer_index;
-	if (device->transfers != NULL) {
-		for (transfer_index = 0; transfer_index < TRANSFER_COUNT;
-		     transfer_index++) {
-			device->transfers[transfer_index]->endpoint = endpoint_address;
-			device->transfers[transfer_index]->callback = callback;
 
-			error = libusb_submit_transfer(device->transfers[transfer_index]);
-			if (error != 0) {
-				last_libusb_error = error;
-				return HACKRF_ERROR_LIBUSB;
-			}
-			device->active_transfers++;
-		}
-		device->transfers_setup = true;
-		device->streaming = true;
-		return HACKRF_SUCCESS;
-	} else {
+	if (device->transfers == NULL) {
 		// This shouldn't happen.
 		return HACKRF_ERROR_OTHER;
 	}
+
+	for (transfer_index = 0; transfer_index < TRANSFER_COUNT; transfer_index++) {
+		device->transfers[transfer_index]->endpoint = endpoint_address;
+		device->transfers[transfer_index]->callback = callback;
+
+		error = libusb_submit_transfer(device->transfers[transfer_index]);
+		if (error != 0) {
+			last_libusb_error = error;
+			return HACKRF_ERROR_LIBUSB;
+		}
+		device->active_transfers++;
+	}
+	device->transfers_setup = true;
+	device->streaming = true;
+	return HACKRF_SUCCESS;
 }
 
 static int detach_kernel_drivers(libusb_device_handle* usb_device_handle)


### PR DESCRIPTION
Currently when starting TX, libhackrf will pre-submit 4 x 256KB transfers of zeroes before any user-supplied samples. This adds a significant delay to transmission.

This PR makes `prepare_transfers` call the TX callback function to pre-fill those initial transfers with sample data. This means that the TX callback will immediately be called four times when `hackrf_start_tx` is called.

A similar change was included in #662, but the implementation here is somewhat different:

- At the time that PR was written, libhackrf started a new transfer thread for each TX or RX session. To implement preload, the `prepare_transfers` call for TX was moved into the transfer thread, before the libusb event handling loop. Now, libhackrf keeps a single transfer thread for each open HackRF device. In this implementation, the preload calls are made directly from the thread calling `hackrf_start_tx`.

- The TX callback is called to fill all four transfers before any are submitted. This ensures that we can't have a situation where a transfer completes and is refilled by the transfer thread before the preload step is completed. This prevents the TX callback from being called concurrently from two different threads, or buffers being filled in the wrong order.
