### PR TITLE
Support flushing the device TX buffer before ending transmission

### DIFF
--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -1391,7 +1391,7 @@ int main(int argc, char** argv)
 	interval_timer.it_value.tv_sec = 0;
 	setitimer(ITIMER_REAL, &interval_timer, NULL);
 #endif
-	if (transmit && !interrupted) {
+	if ((transmit || signalsource) && !interrupted) {
 		// Wait for TX to finish.
 		hackrf_await_tx_flush(device);
 	}

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -1171,6 +1171,7 @@ int main(int argc, char** argv)
 		result |= hackrf_start_rx(device, rx_callback, NULL);
 	} else {
 		result = hackrf_set_txvga_gain(device, txvga_gain);
+		result |= hackrf_enable_tx_flush(device, 1);
 		result |= hackrf_start_tx(device, tx_callback, NULL);
 	}
 	if (result != HACKRF_SUCCESS) {
@@ -1387,6 +1388,10 @@ int main(int argc, char** argv)
 	interval_timer.it_value.tv_sec = 0;
 	setitimer(ITIMER_REAL, &interval_timer, NULL);
 #endif
+	if (transmit) {
+		// Wait for TX to finish.
+		hackrf_await_tx_flush(device);
+	}
 
 	result = hackrf_is_streaming(device);
 	if (do_exit) {

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -104,6 +104,9 @@ typedef enum {
 
 #define USB_CONFIG_STANDARD 0x1
 
+#define RX_ENDPOINT_ADDRESS (LIBUSB_ENDPOINT_IN | 1)
+#define TX_ENDPOINT_ADDRESS (LIBUSB_ENDPOINT_OUT | 2)
+
 typedef enum {
 	HACKRF_TRANSCEIVER_MODE_OFF = 0,
 	HACKRF_TRANSCEIVER_MODE_RECEIVE = 1,
@@ -1239,7 +1242,7 @@ int ADDCALL hackrf_cpld_write(
 	for (i = 0; i < total_length; i += chunk_size) {
 		result = libusb_bulk_transfer(
 			device->usb_device,
-			LIBUSB_ENDPOINT_OUT | 2,
+			TX_ENDPOINT_ADDRESS,
 			&data[i],
 			chunk_size,
 			&transferred,
@@ -1847,7 +1850,7 @@ int ADDCALL hackrf_start_rx(
 	void* rx_ctx)
 {
 	int result;
-	const uint8_t endpoint_address = LIBUSB_ENDPOINT_IN | 1;
+	const uint8_t endpoint_address = RX_ENDPOINT_ADDRESS;
 	device->rx_ctx = rx_ctx;
 	result = hackrf_set_transceiver_mode(device, HACKRF_TRANSCEIVER_MODE_RECEIVE);
 	if (result == HACKRF_SUCCESS) {
@@ -1889,7 +1892,7 @@ int ADDCALL hackrf_start_tx(
 	void* tx_ctx)
 {
 	int result;
-	const uint8_t endpoint_address = LIBUSB_ENDPOINT_OUT | 2;
+	const uint8_t endpoint_address = TX_ENDPOINT_ADDRESS;
 	result = hackrf_set_transceiver_mode(device, HACKRF_TRANSCEIVER_MODE_TRANSMIT);
 	if (result == HACKRF_SUCCESS) {
 		device->tx_ctx = tx_ctx;
@@ -2631,7 +2634,7 @@ int ADDCALL hackrf_start_rx_sweep(
 {
 	USB_API_REQUIRED(device, 0x0104)
 	int result;
-	const uint8_t endpoint_address = LIBUSB_ENDPOINT_IN | 1;
+	const uint8_t endpoint_address = RX_ENDPOINT_ADDRESS;
 	result = hackrf_set_transceiver_mode(device, TRANSCEIVER_MODE_RX_SWEEP);
 	if (HACKRF_SUCCESS == result) {
 		device->rx_ctx = rx_ctx;

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -123,6 +123,7 @@ typedef enum {
 
 #define TRANSFER_COUNT        4
 #define TRANSFER_BUFFER_SIZE  262144
+#define DEVICE_BUFFER_SIZE    32768
 #define USB_MAX_SERIAL_LENGTH 32
 
 struct hackrf_device {
@@ -142,6 +143,8 @@ struct hackrf_device {
 	volatile int active_transfers;  /* number of active transfers */
 	pthread_cond_t all_finished_cv; /* signalled when all transfers have finished */
 	pthread_mutex_t all_finished_lock; /* used to protect all_finished */
+	bool flush;
+	struct libusb_transfer* flush_transfer;
 };
 
 typedef struct {
@@ -272,6 +275,9 @@ static int free_transfers(hackrf_device* device)
 		free(device->transfers);
 		device->transfers = NULL;
 	}
+
+	libusb_free_transfer(device->flush_transfer);
+
 	return HACKRF_SUCCESS;
 }
 
@@ -653,6 +659,8 @@ static int hackrf_open_setup(libusb_device_handle* usb_device, hackrf_device** d
 	lib_device->streaming = false;
 	lib_device->do_exit = false;
 	lib_device->active_transfers = 0;
+	lib_device->flush = false;
+	lib_device->flush_transfer = NULL;
 
 	result = pthread_mutex_init(&lib_device->transfer_lock, NULL);
 	if (result != 0) {
@@ -1692,17 +1700,41 @@ static void transfer_finished(
 	struct hackrf_device* device,
 	struct libusb_transfer* finished_transfer)
 {
+	int result;
+
 	// If a transfer finished for any reason, we're shutting down.
 	device->streaming = false;
 
 	// If this is the last transfer, signal that all are now finished.
 	pthread_mutex_lock(&device->all_finished_lock);
 	if (device->active_transfers == 1) {
-		device->active_transfers = 0;
-		pthread_cond_signal(&device->all_finished_cv);
+		if (device->flush) {
+			// Don't finish yet - flush the TX buffer first.
+			result = libusb_submit_transfer(device->flush_transfer);
+			// If that fails, just shut down.
+			if (result != LIBUSB_SUCCESS) {
+				device->flush = false;
+				device->active_transfers = 0;
+				pthread_cond_broadcast(&device->all_finished_cv);
+			}
+		} else {
+			device->active_transfers = 0;
+			pthread_cond_broadcast(&device->all_finished_cv);
+		}
 	} else {
 		device->active_transfers--;
 	}
+	pthread_mutex_unlock(&device->all_finished_lock);
+}
+
+static void LIBUSB_CALL hackrf_libusb_flush_callback(struct libusb_transfer* usb_transfer)
+{
+	// TX buffer is now flushed, so proceed with signalling completion.
+	hackrf_device* device = (hackrf_device*) usb_transfer->user_data;
+	pthread_mutex_lock(&device->all_finished_lock);
+	device->flush = false;
+	device->active_transfers = 0;
+	pthread_cond_broadcast(&device->all_finished_cv);
 	pthread_mutex_unlock(&device->all_finished_lock);
 }
 
@@ -1893,12 +1925,58 @@ int ADDCALL hackrf_start_tx(
 {
 	int result;
 	const uint8_t endpoint_address = TX_ENDPOINT_ADDRESS;
+	if (device->flush_transfer != NULL) {
+		device->flush = true;
+	}
 	result = hackrf_set_transceiver_mode(device, HACKRF_TRANSCEIVER_MODE_TRANSMIT);
 	if (result == HACKRF_SUCCESS) {
 		device->tx_ctx = tx_ctx;
 		result = prepare_setup_transfers(device, endpoint_address, callback);
 	}
 	return result;
+}
+
+int ADDCALL hackrf_enable_tx_flush(hackrf_device* device, int enable)
+{
+	if (enable) {
+		if (device->flush_transfer) {
+			return HACKRF_SUCCESS;
+		}
+
+		if ((device->flush_transfer = libusb_alloc_transfer(0)) == NULL) {
+			return HACKRF_ERROR_LIBUSB;
+		}
+
+		libusb_fill_bulk_transfer(
+			device->flush_transfer,
+			device->usb_device,
+			TX_ENDPOINT_ADDRESS,
+			calloc(1, DEVICE_BUFFER_SIZE),
+			DEVICE_BUFFER_SIZE,
+			hackrf_libusb_flush_callback,
+			device,
+			0);
+
+		device->flush_transfer->flags = LIBUSB_TRANSFER_FREE_BUFFER;
+	} else {
+		libusb_free_transfer(device->flush_transfer);
+		device->flush_transfer = NULL;
+	}
+
+	return HACKRF_SUCCESS;
+}
+
+int ADDCALL hackrf_await_tx_flush(hackrf_device* device)
+{
+	// Wait for the transfer thread to signal that all transfers
+	// have finished.
+	pthread_mutex_lock(&device->all_finished_lock);
+	while (device->active_transfers > 0) {
+		pthread_cond_wait(&device->all_finished_cv, &device->all_finished_lock);
+	}
+	pthread_mutex_unlock(&device->all_finished_lock);
+
+	return HACKRF_SUCCESS;
 }
 
 /*

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -237,6 +237,9 @@ extern ADDAPI int ADDCALL hackrf_start_tx(
 	hackrf_sample_block_cb_fn callback,
 	void* tx_ctx);
 
+extern ADDAPI int ADDCALL hackrf_enable_tx_flush(hackrf_device* device, int enable);
+extern ADDAPI int ADDCALL hackrf_await_tx_flush(hackrf_device* device);
+
 extern ADDAPI int ADDCALL hackrf_stop_tx(hackrf_device* device);
 
 extern ADDAPI int ADDCALL hackrf_get_m0_state(


### PR DESCRIPTION
This PR adds two new functions to libhackrf:

- `hackf_enable_tx_flush(device, enable)`: When called before `hackrf_start_tx`, this will make libhackrf submit an additional USB transfer containing 32KB of zeros after the last samples from the TX callback. This is the size of the device's TX buffer.

- `hackrf_await_tx_flush(device)`: When called after `hackrf_enable_tx_flush` this will wait until that additional USB transfer completes. Once that happens, it is guaranteed that all user samples have been transmitted, so it is safe to call `hackrf_stop_tx` without truncating the transmission.

These calls are then added to `hackrf_transfer`.