### PR TITLE
operacake: disable the usage of time mode when a portapack is installed

### DIFF
--- a/firmware/common/operacake.c
+++ b/firmware/common/operacake.c
@@ -221,16 +221,19 @@ uint8_t operacake_activate_ports(uint8_t address, uint8_t PA, uint8_t PB)
 	return 0;
 }
 
-void operacake_set_mode(uint8_t address, uint8_t mode)
+bool operacake_set_mode(uint8_t address, uint8_t mode)
 {
 	if (address >= OPERACAKE_MAX_BOARDS) {
-		return;
+		return false;
 	}
 
 	operacake_boards[address].mode = mode;
 	current_range = INVALID_RANGE;
 
 	if (mode == MODE_TIME) {
+		if (!allow_gpio_mode) {
+			return false;
+		}
 		// Switch Opera Cake to pin-control mode
 		uint8_t config_pins = (uint8_t) ~(
 			OPERACAKE_PIN_OE(1) | OPERACAKE_PIN_LEDEN(1) |
@@ -261,6 +264,8 @@ void operacake_set_mode(uint8_t address, uint8_t mode)
 		}
 	}
 	operacake_sctimer_enable(enable_sctimer);
+
+	return true;
 }
 
 uint8_t operacake_get_mode(uint8_t address)

--- a/firmware/common/operacake.h
+++ b/firmware/common/operacake.h
@@ -44,7 +44,7 @@ extern "C" {
 uint8_t operacake_init(bool allow_gpio);
 bool operacake_is_board_present(uint8_t address);
 void operacake_get_boards(uint8_t* addresses);
-void operacake_set_mode(uint8_t address, uint8_t mode);
+bool operacake_set_mode(uint8_t address, uint8_t mode);
 uint8_t operacake_get_mode(uint8_t address);
 uint8_t operacake_set_ports(uint8_t address, uint8_t PA, uint8_t PB);
 uint8_t operacake_add_range(uint16_t freq_min, uint16_t freq_max, uint8_t port);

--- a/firmware/hackrf_usb/usb_api_operacake.c
+++ b/firmware/hackrf_usb/usb_api_operacake.c
@@ -116,7 +116,11 @@ usb_request_status_t usb_vendor_request_operacake_set_mode(
 	address = endpoint->setup.value & 0xFF;
 	mode = endpoint->setup.index & 0xFF;
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
-		operacake_set_mode(address, mode);
+		bool result;
+		result = operacake_set_mode(address, mode);
+		if (!result) {
+			return USB_REQUEST_STATUS_STALL;
+		}
 		usb_transfer_schedule_ack(endpoint->in);
 	}
 	return USB_REQUEST_STATUS_OK;


### PR DESCRIPTION
Fixes #1137 