### PR TITLE
Fix handling of the final <256KiB of data transmitted with `hackrf_transfer`

### DIFF
--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -507,16 +507,11 @@ int tx_callback(hackrf_transfer* transfer)
 		/* Transmit continuous wave with specific amplitude */
 		for (i = 0; i < bytes_to_read; i++)
 			transfer->buffer[i] = -(uint8_t) amplitude;
-
-		if (limit_num_samples && (bytes_to_xfer == 0)) {
-			stop_main_loop();
-			return -1;
-		} else {
-			return 0;
-		}
+		bytes_read = bytes_to_read;
+	} else {
+		bytes_read = fread(transfer->buffer, 1, bytes_to_read, file);
 	}
 
-	bytes_read = fread(transfer->buffer, 1, bytes_to_read, file);
 	if (limit_num_samples && (bytes_to_xfer == 0)) {
 		stop_main_loop();
 		return -1;

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -486,9 +486,8 @@ int tx_callback(hackrf_transfer* transfer)
 	}
 
 	/* Accumulate power (magnitude squared). */
-	bytes_to_read = transfer->valid_length;
 	uint64_t sum = 0;
-	for (i = 0; i < bytes_to_read; i++) {
+	for (i = 0; i < transfer->valid_length; i++) {
 		int8_t value = transfer->buffer[i];
 		sum += value * value;
 	}
@@ -497,6 +496,7 @@ int tx_callback(hackrf_transfer* transfer)
 	byte_count += transfer->valid_length;
 	stream_power += sum;
 
+	bytes_to_read = transfer->buffer_length;
 	if (file == NULL) { // transceiver_mode == TRANSCEIVER_MODE_SS
 		/* Transmit continuous wave with specific amplitude */
 		if (limit_num_samples) {

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -512,6 +512,8 @@ int tx_callback(hackrf_transfer* transfer)
 		bytes_read = fread(transfer->buffer, 1, bytes_to_read, file);
 	}
 
+	transfer->valid_length = bytes_read;
+
 	if (limit_num_samples && (bytes_to_xfer == 0)) {
 		stop_main_loop();
 		return -1;
@@ -533,6 +535,7 @@ int tx_callback(hackrf_transfer* transfer)
 			      1,
 			      bytes_to_read - bytes_read,
 			      file);
+		transfer->valid_length = bytes_read;
 	}
 
 	return 0;

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -497,15 +497,14 @@ int tx_callback(hackrf_transfer* transfer)
 	stream_power += sum;
 
 	bytes_to_read = transfer->buffer_length;
+	if (limit_num_samples) {
+		if (bytes_to_read >= bytes_to_xfer) {
+			bytes_to_read = bytes_to_xfer;
+		}
+		bytes_to_xfer -= bytes_to_read;
+	}
 	if (file == NULL) { // transceiver_mode == TRANSCEIVER_MODE_SS
 		/* Transmit continuous wave with specific amplitude */
-		if (limit_num_samples) {
-			if (bytes_to_read >= bytes_to_xfer) {
-				bytes_to_read = bytes_to_xfer;
-			}
-			bytes_to_xfer -= bytes_to_read;
-		}
-
 		for (i = 0; i < bytes_to_read; i++)
 			transfer->buffer[i] = -(uint8_t) amplitude;
 
@@ -517,16 +516,6 @@ int tx_callback(hackrf_transfer* transfer)
 		}
 	}
 
-	if (limit_num_samples) {
-		if (bytes_to_read >= bytes_to_xfer) {
-			/*
-			 * In this condition, we probably tx some of the previous
-			 * buffer contents at the end.  :-(
-			 */
-			bytes_to_read = bytes_to_xfer;
-		}
-		bytes_to_xfer -= bytes_to_read;
-	}
 	bytes_read = fread(transfer->buffer, 1, bytes_to_read, file);
 	if (limit_num_samples && (bytes_to_xfer == 0)) {
 		stop_main_loop();

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -1176,15 +1176,6 @@ int main(int argc, char** argv)
 		return EXIT_FAILURE;
 	}
 
-	if (transceiver_mode == TRANSCEIVER_MODE_RX) {
-		result = hackrf_set_vga_gain(device, vga_gain);
-		result |= hackrf_set_lna_gain(device, lna_gain);
-		result |= hackrf_start_rx(device, rx_callback, NULL);
-	} else {
-		result = hackrf_set_txvga_gain(device, txvga_gain);
-		result |= hackrf_enable_tx_flush(device, 1);
-		result |= hackrf_start_tx(device, tx_callback, NULL);
-	}
 	if (result != HACKRF_SUCCESS) {
 		fprintf(stderr,
 			"hackrf_start_?x() failed: %s (%d)\n",
@@ -1253,6 +1244,16 @@ int main(int argc, char** argv)
 			usage();
 			return EXIT_FAILURE;
 		}
+	}
+
+	if (transceiver_mode == TRANSCEIVER_MODE_RX) {
+		result = hackrf_set_vga_gain(device, vga_gain);
+		result |= hackrf_set_lna_gain(device, lna_gain);
+		result |= hackrf_start_rx(device, rx_callback, NULL);
+	} else {
+		result = hackrf_set_txvga_gain(device, txvga_gain);
+		result |= hackrf_enable_tx_flush(device, 1);
+		result |= hackrf_start_tx(device, tx_callback, NULL);
 	}
 
 	if (limit_num_samples) {

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -237,6 +237,7 @@ static int cancel_transfers(hackrf_device* device)
 		}
 
 		device->transfers_setup = false;
+		device->flush = false;
 
 		// Now release the lock. It's possible that some transfers were
 		// already complete when we called libusb_cancel_transfer() on


### PR DESCRIPTION
This PR fixes handling of the final samples in a transmission sent with `hackrf_transfer`.

Previously, `hackrf_transfer` would drop the last < 256KiB from of any source of samples, when it could not populate a full transfer buffer.

The changes are:

- Some general cleanup in the `hackrf_transfer` TX callback, to clarify things and avoid duplicated code.
- Make libhackrf honour the `valid_length` set by a TX callback and put this in the libusb transfer length.
- In the `hackrf_transfer` TX callback, set `valid_length` to the bytes put in the buffer when filling a final short transfer.
- After filling the final transfer, return 0 from the callback to submit it, postponing the -1 return until the next call.