### PR TITLE
clean-up and small bug fixes

### DIFF
--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -397,7 +397,7 @@ void stop_main_loop(void)
 #ifdef _WIN32
 	SetEvent(interrupt_handle);
 #else
-	kill(0, SIGALRM);
+	kill(getpid(), SIGALRM);
 #endif
 }
 

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -1249,6 +1249,8 @@ int main(int argc, char** argv)
 		result |= hackrf_set_lna_gain(device, lna_gain);
 		result |= hackrf_start_rx(device, rx_callback, NULL);
 	} else {
+		preload_bytes = hackrf_get_transfer_queue_depth(device) *
+			hackrf_get_transfer_buffer_size(device);
 		result = hackrf_set_txvga_gain(device, txvga_gain);
 		result |= hackrf_enable_tx_flush(device, 1);
 		result |= hackrf_start_tx(device, tx_callback, NULL);
@@ -1279,9 +1281,6 @@ int main(int argc, char** argv)
 		.it_value = {.tv_sec = 1, .tv_usec = 0}};
 	setitimer(ITIMER_REAL, &interval_timer, NULL);
 #endif
-	preload_bytes = hackrf_get_transfer_queue_depth(device) *
-		hackrf_get_transfer_buffer_size(device);
-
 	while ((hackrf_is_streaming(device) == HACKRF_TRUE) && (do_exit == false)) {
 		uint64_t byte_count_now;
 		struct timeval time_now;

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -154,7 +154,9 @@ typedef struct hackrf_device hackrf_device;
 
 /**
  * USB transfer information passed to RX or TX callback.
- * A callback should treat all these fields as read-only except that a TX callback should write to the data buffer.
+ * A callback should treat all these fields as read-only except that a TX
+ * callback should write to the data buffer and may write to valid_length to
+ * indicate that a smaller number of bytes is to be transmitted.
  */
 typedef struct {
 	hackrf_device* device; /**< HackRF USB device for this transfer */


### PR DESCRIPTION
Mostly this is just some simplification and clean-up. Fixes termination of `hackrf_transfer` when called from a script. Also fixes RX stats with small `-n`.