### PR TITLE
Fix hang in TX when a libusb error occurs.

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1830,8 +1830,15 @@ hackrf_libusb_transfer_callback(struct libusb_transfer* usb_transfer)
 			if (resubmit && result == LIBUSB_SUCCESS)
 				return;
 		} else if (device->flush) {
-			libusb_submit_transfer(device->flush_transfer);
+			result = libusb_submit_transfer(device->flush_transfer);
+			if (result != LIBUSB_SUCCESS) {
+				device->streaming = false;
+				device->flush = false;
+			}
 		}
+	} else {
+		device->streaming = false;
+		device->flush = false;
 	}
 
 	// Unless we resubmitted this transfer and returned above,


### PR DESCRIPTION
Where our callback is called with a status other than `LIBUSB_TRANSFER_COMPLETED`, something abnormal has happened and we no longer want to either submit further transfers or await a flush. So clear both the `streaming` and `flush` flags, and proceed to transfer_finished.

Do the same if `libusb_submit_transfer` fails when called from our callback to submit the flush transfer.

This fixes #1163.