### PR TITLE
Provide a callback for TX flush, rather than a wait function.

### DIFF
--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -1413,7 +1413,7 @@ int main(int argc, char** argv)
 
 			time_start = time_now;
 
-			if ((completed_count_now == 0) && (!hw_sync)) {
+			if ((completed_count_now == 0) && (!hw_sync) && (!tx_complete)) {
 				exit_code = EXIT_FAILURE;
 				fprintf(stderr,
 					"\nCouldn't transfer any bytes for one second.\n");

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -513,8 +513,15 @@ int tx_callback(hackrf_transfer* transfer)
 		/* Read samples from file. */
 		bytes_read = fread(transfer->buffer, 1, bytes_to_read, file);
 
-		/* If no more bytes, error or file empty, treat as end. */
-		if (bytes_read == 0) {
+		/* Terminate immediately on error. */
+		if (ferror(file)) {
+			fprintf(stderr, "Could not read input file.\n");
+			stop_main_loop();
+			return -1;
+		}
+
+		/* Finish TX if no more data can be read. */
+		if ((bytes_read == 0) && (ftell(file) < 1)) {
 			tx_complete = true;
 			return 0;
 		}

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -594,9 +594,11 @@ static void tx_complete_callback(hackrf_transfer* transfer, int success)
 	stream_power += sum;
 }
 
-static void flush_callback(void* flush_ctx)
+static void flush_callback(void* flush_ctx, int success)
 {
-	flush_complete = true;
+	if (success) {
+		flush_complete = true;
+	}
 	stop_main_loop();
 }
 

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -543,7 +543,7 @@ int tx_callback(hackrf_transfer* transfer)
 	}
 
 	/* Otherwise, the file ran short. If not repeating, this is the last data. */
-	if (!repeat) {
+	if ((!repeat) || (ftell(file) < 1)) {
 		tx_complete = true;
 		return 0;
 	}

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -513,17 +513,18 @@ int tx_callback(hackrf_transfer* transfer)
 		/* Read samples from file. */
 		bytes_read = fread(transfer->buffer, 1, bytes_to_read, file);
 
-		/* Terminate immediately on error. */
-		if (ferror(file)) {
-			fprintf(stderr, "Could not read input file.\n");
-			stop_main_loop();
-			return -1;
-		}
-
-		/* Finish TX if no more data can be read. */
-		if ((bytes_read == 0) && (ftell(file) < 1)) {
-			tx_complete = true;
-			return 0;
+		/* If no more bytes, error or file empty, terminate. */
+		if (bytes_read == 0) {
+			/* Report any error. */
+			if (ferror(file)) {
+				fprintf(stderr, "Could not read input file.\n");
+				stop_main_loop();
+				return -1;
+			}
+			if (ftell(file) < 1) {
+				stop_main_loop();
+				return -1;
+			}
 		}
 	}
 
@@ -561,8 +562,16 @@ int tx_callback(hackrf_transfer* transfer)
 
 		/* If no more bytes, error or file empty, use what we have. */
 		if (extra_bytes_read == 0) {
-			tx_complete = true;
-			return 0;
+			/* Report any error. */
+			if (ferror(file)) {
+				fprintf(stderr, "Could not read input file.\n");
+				tx_complete = true;
+				return 0;
+			}
+			if (ftell(file) < 1) {
+				tx_complete = true;
+				return 0;
+			}
 		}
 
 		bytes_read += extra_bytes_read;

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -523,6 +523,13 @@ int tx_callback(hackrf_transfer* transfer)
 	} else {
 		/* Read samples from file. */
 		bytes_read = fread(transfer->buffer, 1, bytes_to_read, file);
+
+		/* If no more bytes, error or file empty, treat as end. */
+		if (bytes_read == 0) {
+			completed_byte_count += transfer->valid_length;
+			tx_complete = true;
+			return 0;
+		}
 	}
 
 	/* Accumulate power (magnitude squared). */
@@ -568,6 +575,12 @@ int tx_callback(hackrf_transfer* transfer)
 			      1,
 			      bytes_to_read - bytes_read,
 			      file);
+
+		/* If no more bytes, error or file empty, use what we have. */
+		if (extra_bytes_read == 0) {
+			tx_complete = true;
+			return 0;
+		}
 
 		/* Accumulate power for the additional samples. */
 		sum = 0;

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -367,7 +367,8 @@ static int prepare_transfers(
 				.rx_ctx = device->rx_ctx,
 				.tx_ctx = device->tx_ctx,
 			};
-			if (device->callback(&transfer) == 0) {
+			if ((device->callback(&transfer) == 0) &&
+			    (transfer.valid_length > 0)) {
 				device->transfers[transfer_index]->length =
 					transfer.valid_length;
 				ready_transfers++;
@@ -1810,7 +1811,8 @@ hackrf_libusb_transfer_callback(struct libusb_transfer* usb_transfer)
 	// of stopping them.
 	pthread_mutex_lock(&device->transfer_lock);
 	if (success) {
-		if (device->streaming && device->callback(&transfer) == 0) {
+		if (device->streaming && (device->callback(&transfer) == 0) &&
+		    (transfer.valid_length > 0)) {
 			if ((resubmit = device->transfers_setup)) {
 				if (usb_transfer->endpoint == TX_ENDPOINT_ADDRESS) {
 					usb_transfer->length = transfer.valid_length;

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -239,6 +239,9 @@ static int cancel_transfers(hackrf_device* device)
 			}
 		}
 
+		if (device->flush_transfer != NULL)
+			libusb_cancel_transfer(device->flush_transfer);
+
 		device->transfers_setup = false;
 		device->flush = false;
 

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1770,15 +1770,18 @@ static void* transfer_threadproc(void* arg)
 
 static void LIBUSB_CALL hackrf_libusb_flush_callback(struct libusb_transfer* usb_transfer)
 {
-	// TX buffer is now flushed, so proceed with signalling completion.
+	bool success = usb_transfer->status == LIBUSB_TRANSFER_COMPLETED;
+
+	// All transfers have now ended, so proceed with signalling completion.
 	hackrf_device* device = (hackrf_device*) usb_transfer->user_data;
 	pthread_mutex_lock(&device->all_finished_lock);
 	device->flush = false;
 	device->active_transfers = 0;
 	pthread_cond_broadcast(&device->all_finished_cv);
 	pthread_mutex_unlock(&device->all_finished_lock);
+
 	if (device->flush_callback)
-		device->flush_callback(device->flush_ctx);
+		device->flush_callback(device->flush_ctx, success);
 }
 
 static void LIBUSB_CALL

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -228,6 +228,7 @@ struct hackrf_device_list {
 typedef struct hackrf_device_list hackrf_device_list_t;
 
 typedef int (*hackrf_sample_block_cb_fn)(hackrf_transfer* transfer);
+typedef void (*hackrf_flush_cb_fn)(void* flush_ctx);
 
 #ifdef __cplusplus
 extern "C" {
@@ -270,8 +271,10 @@ extern ADDAPI int ADDCALL hackrf_start_tx(
 	hackrf_sample_block_cb_fn callback,
 	void* tx_ctx);
 
-extern ADDAPI int ADDCALL hackrf_enable_tx_flush(hackrf_device* device, int enable);
-extern ADDAPI int ADDCALL hackrf_await_tx_flush(hackrf_device* device);
+extern ADDAPI int ADDCALL hackrf_enable_tx_flush(
+	hackrf_device* device,
+	hackrf_flush_cb_fn callback,
+	void* flush_ctx);
 
 extern ADDAPI int ADDCALL hackrf_stop_tx(hackrf_device* device);
 

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -229,7 +229,7 @@ typedef struct hackrf_device_list hackrf_device_list_t;
 
 typedef int (*hackrf_sample_block_cb_fn)(hackrf_transfer* transfer);
 typedef void (*hackrf_tx_block_complete_cb_fn)(hackrf_transfer* transfer, int);
-typedef void (*hackrf_flush_cb_fn)(void* flush_ctx);
+typedef void (*hackrf_flush_cb_fn)(void* flush_ctx, int);
 
 #ifdef __cplusplus
 extern "C" {

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -228,6 +228,7 @@ struct hackrf_device_list {
 typedef struct hackrf_device_list hackrf_device_list_t;
 
 typedef int (*hackrf_sample_block_cb_fn)(hackrf_transfer* transfer);
+typedef void (*hackrf_tx_block_complete_cb_fn)(hackrf_transfer* transfer, int);
 typedef void (*hackrf_flush_cb_fn)(void* flush_ctx);
 
 #ifdef __cplusplus
@@ -270,6 +271,10 @@ extern ADDAPI int ADDCALL hackrf_start_tx(
 	hackrf_device* device,
 	hackrf_sample_block_cb_fn callback,
 	void* tx_ctx);
+
+extern ADDAPI int ADDCALL hackrf_set_tx_block_complete_callback(
+	hackrf_device* device,
+	hackrf_tx_block_complete_cb_fn callback);
 
 extern ADDAPI int ADDCALL hackrf_enable_tx_flush(
 	hackrf_device* device,


### PR DESCRIPTION
This fixes #1164, but currently causes some erroneous output to be printed in `hackrf_transfer` e.g:
```
$ hackrf_transfer -c 0 -n 100000
call hackrf_set_sample_rate(10000000 Hz/10.000 MHz)
call hackrf_set_hw_sync_mode(0)
call hackrf_set_freq(900000000 Hz/900.000 MHz)
samples_to_xfer 100000/0Mio
Stop with Ctrl-C
 0.0 MiB / 0.011 sec =  0.0 MiB/second, average power -nan dBfs

Couldn't transfer any bytes for one second.
```