### PR TITLE
Fix initial state of RF path GPIOs.

### DIFF
--- a/firmware/common/rf_path.c
+++ b/firmware/common/rf_path.c
@@ -341,7 +341,7 @@ void rf_path_init(rf_path_t* const rf_path)
 #ifndef HACKRF_ONE
 	mixer_setup(&mixer);
 #endif
-	(void) rf_path; /* silence unused param warning */
+	rf_path->switchctrl = SWITCHCTRL_SAFE;
 }
 
 void rf_path_set_direction(rf_path_t* const rf_path, const rf_path_direction_t direction)

--- a/firmware/common/rf_path.c
+++ b/firmware/common/rf_path.c
@@ -267,6 +267,12 @@ void rf_path_pin_setup(rf_path_t* const rf_path)
 	/* Configure RF power supply (VAA) switch */
 	scu_pinmux(SCU_NO_VAA_ENABLE, SCU_GPIO_FAST | SCU_CONF_FUNCTION0);
 
+	/*
+	 * Safe (initial) switch settings turn off both amplifiers and antenna port
+	 * power and enable both amp bypass and mixer bypass.
+	 */
+	switchctrl_set(rf_path, SWITCHCTRL_SAFE);
+
 	/* Configure RF switch control signals as outputs */
 	gpio_output(rf_path->gpio_amp_bypass);
 	gpio_output(rf_path->gpio_no_mix_bypass);
@@ -281,12 +287,6 @@ void rf_path_pin_setup(rf_path_t* const rf_path)
 	gpio_output(rf_path->gpio_tx);
 	gpio_output(rf_path->gpio_mix_bypass);
 	gpio_output(rf_path->gpio_rx);
-
-	/*
-	 * Safe (initial) switch settings turn off both amplifiers and antenna port
-	 * power and enable both amp bypass and mixer bypass.
-	 */
-	switchctrl_set(rf_path, SWITCHCTRL_AMP_BYPASS | SWITCHCTRL_MIX_BYPASS);
 #elif RAD1O
 	/* Configure RF switch control signals */
 	// clang-format off
@@ -306,6 +306,12 @@ void rf_path_pin_setup(rf_path_t* const rf_path)
 	/* Configure RF power supply (VAA) switch */
 	scu_pinmux(SCU_VAA_ENABLE, SCU_GPIO_FAST | SCU_CONF_FUNCTION0);
 
+	/*
+	 * Safe (initial) switch settings turn off both amplifiers and antenna port
+	 * power and enable both amp bypass and mixer bypass.
+	 */
+	switchctrl_set(rf_path, SWITCHCTRL_SAFE);
+
 	/* Configure RF switch control signals as outputs */
 	gpio_output(rf_path->gpio_tx_rx_n);
 	gpio_output(rf_path->gpio_tx_rx);
@@ -318,12 +324,6 @@ void rf_path_pin_setup(rf_path_t* const rf_path)
 	gpio_output(rf_path->gpio_low_high_filt_n);
 	gpio_output(rf_path->gpio_tx_amp);
 	gpio_output(rf_path->gpio_rx_lna);
-
-	/*
-	 * Safe (initial) switch settings turn off both amplifiers and antenna port
-	 * power and enable both amp bypass and mixer bypass.
-	 */
-	switchctrl_set(rf_path, SWITCHCTRL_AMP_BYPASS | SWITCHCTRL_MIX_BYPASS);
 #else
 	(void) rf_path; /* silence unused param warning */
 #endif

--- a/firmware/common/rf_path.c
+++ b/firmware/common/rf_path.c
@@ -79,8 +79,6 @@
 		 SWITCHCTRL_MIX_BYPASS | SWITCHCTRL_HP | SWITCHCTRL_NO_RX_AMP_PWR)
 #endif
 
-uint8_t switchctrl = SWITCHCTRL_SAFE;
-
 /*
  * Antenna port power on HackRF One is controlled by GPO1 on the RFFC5072.
  * This is the only thing we use RFFC5072 GPO for on HackRF One.  The value of
@@ -343,7 +341,7 @@ void rf_path_init(rf_path_t* const rf_path)
 #ifndef HACKRF_ONE
 	mixer_setup(&mixer);
 #endif
-	switchctrl_set(rf_path, switchctrl);
+	(void) rf_path; /* silence unused param warning */
 }
 
 void rf_path_set_direction(rf_path_t* const rf_path, const rf_path_direction_t direction)


### PR DESCRIPTION
Previously `rf_path_pin_setup` would set up the GPIOs with:

`switchctrl_set(rf_path, SWITCHCTRL_AMP_BYPASS | SWITCHCTRL_MIX_BYPASS)`

However, this misses out `SWITCHCTRL_NO_TX_AMP_PWR` and `SWITCHCTRL_NO_RX_AMP_PWR` which are needed to keep the amps off. The correct setting to use is defined as `SWITCHCTRL_SAFE`. The call was also made after setting the GPIOs to output mode, so there could be a brief glitch.

The `SWITCHCTRL_SAFE` value was being assigned to the global `switchctrl` setting but this was only used once, in `rf_path_init`, which does apply that state shortly after `rf_path_pin_setup`. However, all other functions use `rf_path->switchctrl`, not the global `switchctrl`, which was never being initialised at all.

This PR corrects these issues, which fixes #1169.