### PR TITLE
Flush queues on control endpoint when a new SETUP is received.

### DIFF
--- a/firmware/common/usb_request.c
+++ b/firmware/common/usb_request.c
@@ -60,6 +60,11 @@ static void usb_request(usb_endpoint_t* const endpoint, const usb_transfer_stage
 
 void usb_setup_complete(usb_endpoint_t* const endpoint)
 {
+	// If we've received a new SETUP token, then any previously
+	// in-progress request is now aborted.
+	usb_endpoint_flush(endpoint->in);
+	usb_endpoint_flush(endpoint->out);
+
 	usb_request(endpoint, USB_TRANSFER_STAGE_SETUP);
 }
 


### PR DESCRIPTION
On macOS 12.6 running libusb 1.0.26, the host was seen to sometimes make an incomplete `ClearFeature(ENDPOINT_HALT)` request when `ClearPipeStallBothEnds` was called from `libusb_cancel_transfer`.

The host would send the SETUP packet, and the firmware would call `usb_transfer_schedule_ack` to acknowledge the upcoming IN token. However, the host would then not send the IN token, proceeding directly to the next SETUP:

![image](https://user-images.githubusercontent.com/673823/192480518-fec0691b-3e71-405d-bab6-4844bbd9507a.png)

Since an empty transfer was queued to schedule the ACK, the firmware would leak one transfer from the `free_transfers` list.

After a few iterations of this, the firmware would run out of free transfers and the next request would hang waiting for one.

Fix this by flushing the transfer queues for the control endpoint when a new SETUP is received, since that token implicitly cancels any previously ongoing request.