### PR TITLE
set version to 2022.09.1

### DIFF
--- a/firmware/hackrf-common.cmake
+++ b/firmware/hackrf-common.cmake
@@ -52,7 +52,6 @@ ExternalProject_Add(libopencm3_${PROJECT_NAME}
 	INSTALL_COMMAND ""
 )
 
-#set(VERSION "")
 if (NOT DEFINED VERSION)
 	execute_process(
 		COMMAND git log -n 1 --format=%h
@@ -63,7 +62,7 @@ if (NOT DEFINED VERSION)
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 	)
 	if (GIT_VERSION_FOUND)
-		set(VERSION "unknown")
+		set(VERSION "2022.09.1")
 	else (GIT_VERSION_FOUND)
 		set(VERSION "git-${GIT_VERSION}")
 	endif (GIT_VERSION_FOUND)

--- a/host/cmake/set_release.cmake
+++ b/host/cmake/set_release.cmake
@@ -1,5 +1,3 @@
-#set(RELEASE "")
-
 if(NOT DEFINED RELEASE)
 	execute_process(
 	        COMMAND git log -n 1 --format=%h
@@ -10,7 +8,7 @@ if(NOT DEFINED RELEASE)
 	        OUTPUT_STRIP_TRAILING_WHITESPACE
 	)
 	if (GIT_EXIT_VALUE)
-	        set(RELEASE "unknown")
+	        set(RELEASE "2022.09.1")
 	else (GIT_EXIT_VALUE)
 		execute_process(
 			COMMAND git status -s --untracked-files=no


### PR DESCRIPTION
Starting with this release we will no longer use "unknown" as the default software version string used in cases where the version cannot be determined from context. Instead we commit the release version string to git so that any software built from the tagged commit will have the appropriate release version string. After the release we will commit a post-release version string as the new default.

We will continue to use the commit hash as version string when the software is built inside a git repository.