### PR TITLE
Reduce firmware USB transfer size from 16KB to 8KB

### DIFF
--- a/firmware/hackrf_usb/usb_api_transceiver.c
+++ b/firmware/hackrf_usb/usb_api_transceiver.c
@@ -45,7 +45,7 @@
 #include "usb_endpoint.h"
 #include "usb_api_sweep.h"
 
-#define USB_TRANSFER_SIZE 0x4000
+#define USB_TRANSFER_SIZE 0x2000
 
 typedef struct {
 	uint32_t freq_mhz;
@@ -451,7 +451,8 @@ void tx_mode(uint32_t seq)
 			baseband_streaming_enable(&sgpio_config);
 			started = true;
 		}
-		if ((usb_count - m0_state.m0_count) <= USB_TRANSFER_SIZE) {
+		if ((usb_count - m0_state.m0_count) <=
+		    (USB_BULK_BUFFER_SIZE - USB_TRANSFER_SIZE)) {
 			usb_transfer_schedule_block(
 				&usb_endpoint_bulk_out,
 				&usb_bulk_buffer[usb_count & USB_BULK_BUFFER_MASK],


### PR DESCRIPTION
This PR reduces the size of firmware-side USB transfers from 16KB to 8KB: a quarter of the available buffer, rather than half.

This provides greatly improved throughput in practice:

* With 16KB transfers, Windows and macOS would both typically fail to maintain sufficient USB throughput above 16-17Msps sample rates, with only Linux sustaining 20Msps. With 8KB transfers, all three operating systems now sustain 20Msps. 

* With 16KB transfers, Linux would sustain 20Msps TX but with occasional brief underruns. With 8KB transfers, there are none. Buffer stats printed from `hackrf_transfer -B` clearly show a higher and more consistent level of data in the buffer.

The smaller transfer size helps because it reduces sensitivity to latency. Previously, the device had to NAK the IN/OUT tokens from the host until there was a full 16KB of data or buffer space ready. Using the largest possible chunks is efficient, but means the device can miss chances to send some data when it could. If the host then polls late, it may be hard to recover.

It seems like the 16KB size interacted poorly with Windows and macOS, which would both give up polling just before the next chunk became ready, and then retry too late to recover before a shortfall occured. Linux probably performed better due to polling more aggressively.

8KB has been chosen as a sweet spot: going further down to 4KB transfers has been tested but collapses the RX performance.