### PR TITLE
m0: reset M0 before starting it

### DIFF
--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -241,6 +241,7 @@ int main(void)
 	cpu_clock_init();
 
 	/* Wake the M0 */
+	ipc_halt_m0();
 	ipc_start_m0((uint32_t) &__ram_m0_start__);
 
 	if (!cpld_jtag_sram_load(&jtag_cpld)) {


### PR DESCRIPTION
The rad1o was not starting the M0 when powered up by inserting a USB cable. Interestingly the M0 does start when toggling the power switch.

Resetting the M0 before starting it in `main()` solves this issue.