### PR TITLE
Remove default titles from issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: Bug Report 
 description: Submit a bug report
-title: "[Bug Report]: "
 labels: ["bug report"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/documentation-request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-request.yml
@@ -1,6 +1,5 @@
 name: Documentation 
 description: Make a request regarding HackRF documentation 
-title: "[Documentation]: "
 labels: ["documentation"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,5 @@
 name: Feature Request 
 description: File a feature request
-title: "[Feature Request]: "
 labels: ["enhancement"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,6 +1,5 @@
 name: Question  
 description: Ask a question not covered by current hackrf.rtfd.io documentation 
-title: "[Question]: "
 labels: ["question"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/technical-support.yml
+++ b/.github/ISSUE_TEMPLATE/technical-support.yml
@@ -13,8 +13,8 @@ body:
     attributes: 
       label: Have you read the HackRF [troubleshooting documentation](https://hackrf.readthedocs.io/en/latest/troubleshooting.html)?
       options:
-        - "yes"
         - "no"
+        - "yes"        
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/technical-support.yml
+++ b/.github/ISSUE_TEMPLATE/technical-support.yml
@@ -1,6 +1,5 @@
 name: Technical Support Request
 description: File a technical support request
-title: "[Tech Support]: "
 labels: ["technical support"]
 assignees:
   - straithe


### PR DESCRIPTION
This removes the pre-populated titles from the issue form templates. I think in practice they end up being confusing, and users often either overwrite them or leave the title empty. Since the template adds labels to the issues anyway, I think we can remove the title tags.