### PR TITLE
Make definition of "prev" consistent

### DIFF
--- a/firmware/hackrf_usb/sgpio_m0.s
+++ b/firmware/hackrf_usb/sgpio_m0.s
@@ -566,7 +566,7 @@ checked_rollback:
 	beq idle                                        //      goto idle                       // 3
 
 	// Otherwise, roll back the state to ignore the current shortfall, then jump to idle.
-	prev .req r0
+	prev .req r1
 	ldr prev, [state, #PREV_LONGEST_SHORTFALL]      // prev = prev_longest_shortfall        // 2
 	str prev, [state, #LONGEST_SHORTFALL]           // state.longest_shortfall = prev       // 2
 	ldr prev, [state, #NUM_SHORTFALLS]              // prev = num_shortfalls                // 2


### PR DESCRIPTION
The definition of `prev` is `r1` at line 360 in macro `handle_shortfall`, but is later changed to `r0` in `checked_rollback` at line 569.  This causes a warning message:

`sgpio_m0.s:569: Warning: ignoring redefinition of register alias 'prev'`

Doing a disassembly shows that the assembler indeed ignores the redefinition and uses `r1` in `checked_rollback`.

This pull request simply changes the definition in `checked_rollback` to match what macro `handle_shortfall` is using, and thus eliminates the warning without actually changing the binary code that is generated.