### PR TITLE
Add Windows build of libhackrf and host tools to Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,6 @@ on:
   schedule:
     - cron: 1 12 * * 1
 
-env:
-  BUILD_TYPE: Release
-
 jobs:
   host:
     strategy:
@@ -40,12 +37,12 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/host/build
-      run: cmake $GITHUB_WORKSPACE/host/ -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE/host/ -DCMAKE_BUILD_TYPE=Release
 
     - name: Build
       working-directory: ${{runner.workspace}}/host/build
       shell: bash
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build . --config Release
 
     - name: Create Build Environment (libhackrf)
       run: cmake -E make_directory ${{runner.workspace}}/host/libhackrf/build
@@ -53,18 +50,18 @@ jobs:
     - name: Configure CMake (libhackrf)
       shell: bash
       working-directory: ${{runner.workspace}}/host/libhackrf/build
-      run: cmake $GITHUB_WORKSPACE/host/libhackrf/ -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE/host/libhackrf/ -DCMAKE_BUILD_TYPE=Release
 
     - name: Build (libhackrf)
       working-directory: ${{runner.workspace}}/host/libhackrf/build
       shell: bash
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build . --config Release
 
     - name: Install (libhackrf)
       working-directory: ${{runner.workspace}}/host/libhackrf/build
       shell: bash
       run: |
-        sudo cmake --install . --config $BUILD_TYPE
+        sudo cmake --install . --config Release
 
     - name: Create Build Environment (hackrf-tools)
       run: cmake -E make_directory ${{runner.workspace}}/host/hackrf-tools/build
@@ -72,12 +69,12 @@ jobs:
     - name: Configure CMake (hackrf-tools)
       shell: bash
       working-directory: ${{runner.workspace}}/host/hackrf-tools/build
-      run: cmake $GITHUB_WORKSPACE/host/hackrf-tools/ -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE/host/hackrf-tools/ -DCMAKE_BUILD_TYPE=Release
 
     - name: Build (hackrf-tools)
       working-directory: ${{runner.workspace}}/host/hackrf-tools/build
       shell: bash
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build . --config Release
 
   firmware:
     strategy:
@@ -117,10 +114,10 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/firmware/build
-      run: cmake $GITHUB_WORKSPACE/firmware/ -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBOARD=${{ matrix.board }}
+      run: cmake $GITHUB_WORKSPACE/firmware/ -DCMAKE_BUILD_TYPE=Release -DBOARD=${{ matrix.board }}
 
     - name: Build
       working-directory: ${{runner.workspace}}/firmware/build
       shell: bash
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build . --config Release
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,31 +35,26 @@ jobs:
       run: cmake -E make_directory ${{runner.workspace}}/host/build
 
     - name: Configure CMake
-      shell: bash
       working-directory: ${{runner.workspace}}/host/build
       run: cmake $GITHUB_WORKSPACE/host/ -DCMAKE_BUILD_TYPE=Release
 
     - name: Build
       working-directory: ${{runner.workspace}}/host/build
-      shell: bash
       run: cmake --build . --config Release
 
     - name: Create Build Environment (libhackrf)
       run: cmake -E make_directory ${{runner.workspace}}/host/libhackrf/build
 
     - name: Configure CMake (libhackrf)
-      shell: bash
       working-directory: ${{runner.workspace}}/host/libhackrf/build
       run: cmake $GITHUB_WORKSPACE/host/libhackrf/ -DCMAKE_BUILD_TYPE=Release
 
     - name: Build (libhackrf)
       working-directory: ${{runner.workspace}}/host/libhackrf/build
-      shell: bash
       run: cmake --build . --config Release
 
     - name: Install (libhackrf)
       working-directory: ${{runner.workspace}}/host/libhackrf/build
-      shell: bash
       run: |
         sudo cmake --install . --config Release
 
@@ -67,13 +62,11 @@ jobs:
       run: cmake -E make_directory ${{runner.workspace}}/host/hackrf-tools/build
 
     - name: Configure CMake (hackrf-tools)
-      shell: bash
       working-directory: ${{runner.workspace}}/host/hackrf-tools/build
       run: cmake $GITHUB_WORKSPACE/host/hackrf-tools/ -DCMAKE_BUILD_TYPE=Release
 
     - name: Build (hackrf-tools)
       working-directory: ${{runner.workspace}}/host/hackrf-tools/build
-      shell: bash
       run: cmake --build . --config Release
 
   firmware:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,19 @@ on:
   schedule:
     - cron: 1 12 * * 1
 
+env:
+  WIN_LIBUSB_INC: -DLIBUSB_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include/libusb-1.0
+  WIN_LIBUSB_LIB: -DLIBUSB_LIBRARIES=C:/vcpkg/installed/x64-windows/lib/libusb-1.0.lib
+  WIN_FFTW_INC: -DFFTW_INCLUDES=C:/vcpkg/installed/x64-windows/include
+  WIN_FFTW_LIB: -DFFTW_LIBRARIES=C:/vcpkg/installed/x64-windows/lib/fftw3f.lib
+  WIN_PTHREAD_INC: -DTHREADS_PTHREADS_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include
+  WIN_PTHREAD_LIB: -DTHREADS_PTHREADS_WIN32_LIBRARY=C:/vcpkg/installed/x64-windows/lib/pthreadvc3.lib
+
 jobs:
   host:
     strategy:
       matrix:
-        os: ['macos-latest', 'ubuntu-latest']
+        os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
 
       # Don't cancel all builds when one fails
       fail-fast: false
@@ -31,12 +39,22 @@ jobs:
         sudo apt install libfftw3-dev libusb-1.0-0-dev
       if: matrix.os == 'ubuntu-latest'
 
+    - name: Install dependencies (Windows)
+      run: vcpkg install --triplet=x64-windows libusb fftw3 pthreads
+      if: matrix.os == 'windows-latest'
+
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/host/build
 
     - name: Configure CMake
       working-directory: ${{runner.workspace}}/host/build
       run: cmake $GITHUB_WORKSPACE/host/ -DCMAKE_BUILD_TYPE=Release
+      if: matrix.os != 'windows-latest'
+
+    - name: Configure CMake (Windows)
+      working-directory: ${{runner.workspace}}/host/build
+      run: cmake $env:GITHUB_WORKSPACE/host/ $env:WIN_LIBUSB_INC $env:WIN_LIBUSB_LIB $env:WIN_FFTW_INC $env:WIN_FFTW_LIB $env:WIN_PTHREAD_INC $env:WIN_PTHREAD_LIB
+      if: matrix.os == 'windows-latest'
 
     - name: Build
       working-directory: ${{runner.workspace}}/host/build
@@ -48,6 +66,12 @@ jobs:
     - name: Configure CMake (libhackrf)
       working-directory: ${{runner.workspace}}/host/libhackrf/build
       run: cmake $GITHUB_WORKSPACE/host/libhackrf/ -DCMAKE_BUILD_TYPE=Release
+      if: matrix.os != 'windows-latest'
+
+    - name: Configure CMake (libhackrf, Windows)
+      working-directory: ${{runner.workspace}}/host/libhackrf/build
+      run: cmake $env:GITHUB_WORKSPACE/host/libhackrf/ $env:WIN_LIBUSB_INC $env:WIN_LIBUSB_LIB $env:WIN_PTHREAD_INC $env:WIN_PTHREAD_LIB
+      if: matrix.os == 'windows-latest'
 
     - name: Build (libhackrf)
       working-directory: ${{runner.workspace}}/host/libhackrf/build
@@ -57,6 +81,13 @@ jobs:
       working-directory: ${{runner.workspace}}/host/libhackrf/build
       run: |
         sudo cmake --install . --config Release
+      if: matrix.os != 'windows-latest'
+
+    - name: Install (libhackrf, Windows)
+      working-directory: ${{runner.workspace}}/host/libhackrf/build
+      run: |
+        cmake --install . --config Release --prefix=$env:GITHUB_WORKSPACE/install
+      if: matrix.os == 'windows-latest'
 
     - name: Create Build Environment (hackrf-tools)
       run: cmake -E make_directory ${{runner.workspace}}/host/hackrf-tools/build
@@ -64,10 +95,21 @@ jobs:
     - name: Configure CMake (hackrf-tools)
       working-directory: ${{runner.workspace}}/host/hackrf-tools/build
       run: cmake $GITHUB_WORKSPACE/host/hackrf-tools/ -DCMAKE_BUILD_TYPE=Release
+      if: matrix.os != 'windows-latest'
+
+    - name: Configure CMake (hackrf-tools, Windows)
+      working-directory: ${{runner.workspace}}/host/hackrf-tools/build
+      run: |
+        cmake $env:GITHUB_WORKSPACE/host/hackrf-tools/ $env:WIN_FFTW_INC $env:WIN_FFTW_LIB -DLIBHACKRF_INCLUDE_DIR=$env:GITHUB_WORKSPACE/install/include/libhackrf -DLIBHACKRF_LIBRARIES=$env:GITHUB_WORKSPACE/install/bin/hackrf.lib
+      if: matrix.os == 'windows-latest'
 
     - name: Build (hackrf-tools)
       working-directory: ${{runner.workspace}}/host/hackrf-tools/build
       run: cmake --build . --config Release
+      # This step should work on Windows too, but currently MSVC fails to find
+      # hackrf.h, despite us having installed it and specified its location in
+      # the previous steps above.
+      if: matrix.os != 'windows-latest'
 
   firmware:
     strategy:


### PR DESCRIPTION
This PR adds a Windows MSVC build of libhackrf and the host tools to our existing Github Actions workflow. The aim is to replace the current Appveyor builds, which use outdated dependencies and require a separate CI platform.

The build uses the current GitHub `windows-latest` runner. The dependencies (libusb, pthreads and fftw) are first installed via [vcpkg](https://github.com/microsoft/vcpkg/). The latest versions currently available through the installed vcpkg will be used.

Builds are then configured, passing all the necessary header and library paths to CMake's configure step, which generates MSBuild project files. Ideally, explicitly specifying the paths should be eliminated in future by having our CMake scripts integrate better with vcpkg, but the current approach works for now without changes to our build system.

As with the Linux and macOS builds, first libhackrf and the host tools are built together, then libhackrf is built on its own and installed. The host tools are then configured to be built separately against the installed copy of libhackrf.

However, the final build of the host tools against the installed libhackrf is skipped, because MSVC fails to find `hackrf.h`. I don't currently know why. The header is installed where it should be, and the configure step succeeds with the `LIBHACKRF_INCLUDE_DIR` set to that location. I was not able to reproduce the failure locally with the same steps.

This doesn't seem like a significant problem however, as the combined build of the `host` directory still verifies that the code builds successfully under Windows and MSVC.