### PR TITLE
wrap clkin init in r9 board check

### DIFF
--- a/firmware/common/hackrf_core.c
+++ b/firmware/common/hackrf_core.c
@@ -534,7 +534,7 @@ bool baseband_filter_bandwidth_set(const uint32_t bandwidth_hz)
 	return bandwidth_hz_real != 0;
 }
 
-/* 
+/*
 Configure PLL1 (Main MCU Clock) to max speed (204MHz).
 Note: PLL1 clock is used by M4/M0 core, Peripheral, APB1.
 This function shall be called after cpu_clock_init().
@@ -812,9 +812,6 @@ void cpu_clock_init(void)
 	// CCU2_CLK_SDIO_CFG = 0;
 #endif
 
-	if (detected_platform() == BOARD_ID_HACKRF1_R9) {
-		clkin_detect_init();
-	}
 }
 
 clock_source_t activate_best_clock_source(void)

--- a/firmware/common/hackrf_core.c
+++ b/firmware/common/hackrf_core.c
@@ -811,7 +811,6 @@ void cpu_clock_init(void)
 	// CCU2_CLK_APLL_CFG = 0;
 	// CCU2_CLK_SDIO_CFG = 0;
 #endif
-
 }
 
 clock_source_t activate_best_clock_source(void)

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -288,7 +288,11 @@ int main(void)
 	}
 	operacake_init(operacake_allow_gpio);
 
-	clkin_detect_init();
+	// FIXME: clock detection on r9 only works when calling init twice
+	if (detected_platform() == BOARD_ID_HACKRF1_R9) {
+		clkin_detect_init();
+		clkin_detect_init();
+	}
 
 	while (true) {
 		transceiver_request_t request;


### PR DESCRIPTION
fixes #1292; requires two calls to clkin_detect_init which should also be fixed