### PR TITLE
Run fftw_execute() once on an empty buffer (Fix #1366), add option to save wisdom and specify plan (#863)

### DIFF
--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -413,25 +413,29 @@ void sigint_callback_handler(int signum)
 }
 #endif
 
-int import_wisdom(const char* path) {
+int import_wisdom(const char* path)
+{
 	// Returns nonzero
-	if (! fftwf_import_wisdom_from_filename(path)) {
-		fprintf(stderr,"Wisdom file %s not found; will attempt to create it\n",path);
+	if (!fftwf_import_wisdom_from_filename(path)) {
+		fprintf(stderr,
+			"Wisdom file %s not found; will attempt to create it\n",
+			path);
 		return 0;
 	}
 
 	return 1;
 }
 
-int import_system_wisdom() {
-	// Returns nonzero on success
+int import_default_wisdom()
+{
 	return fftwf_import_system_wisdom();
 }
 
-int export_wisdom(const char* path) {
+int export_wisdom(const char* path)
+{
 	if (path != NULL) {
 		if (!fftwf_export_wisdom_to_filename(path)) {
-			fprintf(stderr,"Could not write FFTW wisdom file to %s",path);
+			fprintf(stderr, "Could not write FFTW wisdom file to %s", path);
 			return 0;
 		}
 	}
@@ -524,20 +528,16 @@ int main(int argc, char** argv)
 			break;
 
 		case 'P':
-			if (strcmp("estimate",optarg) == 0) {
+			if (strcmp("estimate", optarg) == 0) {
 				fftw_plan_type = FFTW_ESTIMATE;
-			}
-			else if (strcmp("measure",optarg) == 0) {
+			} else if (strcmp("measure", optarg) == 0) {
 				fftw_plan_type = FFTW_MEASURE;
-			}
-			else if (strcmp("patient",optarg) == 0) {
+			} else if (strcmp("patient", optarg) == 0) {
 				fftw_plan_type = FFTW_PATIENT;
-			}
-			else if (strcmp("exhaustive",optarg) == 0) {
+			} else if (strcmp("exhaustive", optarg) == 0) {
 				fftw_plan_type = FFTW_EXHAUSTIVE;
-			}
-			else {
-				fprintf(stderr,"Unknown FFTW plan type '%s'\n",optarg);
+			} else {
+				fprintf(stderr, "Unknown FFTW plan type '%s'\n", optarg);
 				return EXIT_FAILURE;
 			}
 
@@ -585,13 +585,8 @@ int main(int argc, char** argv)
 	if (fftwWisdomPath) {
 		have_wisdom = import_wisdom(fftwWisdomPath);
 	} else {
-		if (! (have_wisdom = import_system_wisdom())) {
-			// Could possibly notify the user that there is no accessible
-			// system-wide FFTW wisdom file and to consider using the -W
-			// option to improve performance on subsequent runs
-		}
+		have_wisdom = import_default_wisdom();
 	}
-
 
 	if (lna_gain % 8) {
 		fprintf(stderr, "warning: lna_gain (-l) must be a multiple of 8\n");
@@ -684,7 +679,6 @@ int main(int argc, char** argv)
 	 * data starts to flow.  See issue #1366
 	*/
 	fftwf_execute(fftwPlan);
-
 
 #ifdef _MSC_VER
 	if (binary_output) {

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -458,7 +458,6 @@ int main(int argc, char** argv)
 	uint32_t freq_max = 6000;
 	uint32_t requested_fft_bin_width;
 	const char* fftwWisdomPath = NULL;
-	int have_wisdom = 0;
 	int fftw_plan_type = FFTW_MEASURE;
 
 	while ((opt = getopt(argc, argv, "a:f:p:l:g:d:n:N:w:W:P:1BIr:h?")) != EOF) {

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -582,9 +582,9 @@ int main(int argc, char** argv)
 	// Try to load a wisdom file if specified, otherwise
 	// try to load the system-wide wisdom file
 	if (fftwWisdomPath) {
-		have_wisdom = import_wisdom(fftwWisdomPath);
+		import_wisdom(fftwWisdomPath);
 	} else {
-		have_wisdom = import_default_wisdom();
+		import_default_wisdom();
 	}
 
 	if (lna_gain % 8) {


### PR DESCRIPTION
Runs fftw_execute() once on an empty buffer to make sure the plan
is generated before streaming begins.  Fixes #1366 and should fix #1260.

Implements #863, with some changes:

1. Adds a -W option to specify a wisdom file.  If the necessary wisdom does not exist (either because the file does not exist, or an equivalent or better plan does not exist in the file) we attempt to save it at program exit.
   
2. Adds a -P option to specify the planner flags (estimate, measure, patient, exhaustive).
   
3. There is no reason to use the WISDOM_ONLY flag; FFTW will automatically use the best plan it can find in the wisdom file OR generate a new plan if none exists.  This wisdom will be saved for future use (see point 1) if the -W option is specified; we do not attempt to update the system-wide wisdom file.
   
4.  FFTW already has a notion of a default system-wide wisdom file.  If the -W option is not specified we attempt to load it; if it does not exist we don't complain.
   
Some notes:

- specifying  wisdom file on the Raspberry Pi *greatly* reduces the startup time on subsequent runs.  Without a wisdom file, a 10K bin size with the default "measure" plan on a RPI4 takes about 30 seconds to start executing.  With a wisdom file the startup time is negligible

- FFTW's "import system wide wisdom file" seems to always fail on the RPI (and possibly other systems as well), and the 'canonical' wisdom file generated by fftwf-wisdom doesn't seem to have any hints that help anyway.  If a user wants a system-wide wisdom file that works with hackrf_sweep, it's recommended that they generate one using the -W option to hackrf_sweep and then copy it somewhere that all user accounts can access it and chmod it/set the ACL appropriately.  Determining the right way to do this on every possible OS that hackrf can be used with seems like it's way beyond the scope of this tool.