### PR TITLE
Switch to gcc-arm-embedded package for macOS CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,8 +128,8 @@ jobs:
 
     - name: Install dependencies (macOS)
       run: |
-        brew tap armmbed/formulae
-        brew install arm-none-eabi-gcc dfu-util
+        brew install --cask gcc-arm-embedded
+        brew install dfu-util
         pip3 install PyYAML
       if: matrix.os == 'macos-latest'
 


### PR DESCRIPTION
This fixes the macOS firmware builds.