### PR TITLE
Add '#include <io.h>'

### DIFF
--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -47,6 +47,7 @@ typedef int bool;
 #ifdef _WIN32
 	#define _USE_MATH_DEFINES
 	#include <windows.h>
+	#include <io.h>
 	#ifdef _MSC_VER
 
 		#ifdef _WIN64


### PR DESCRIPTION
Compiling with clang-cl, gives this error:
```c
hackrf-tools/src/hackrf_sweep.c(685,3): error: call to undeclared function '_setmode'; ISO C99 and later do not support implicit function
      declarations [-Wimplicit-function-declaration]
  685 |                 _setmode(_fileno(stdout), _O_BINARY);
      |                 ^
```

fixed by simply adding `#include <io.h>`.