### PR TITLE
Update CMAKE minimum version to 2.8.12

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -1,6 +1,6 @@
 #top dir cmake project for libhackrf + tools
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1.3)
 project (HackRF C)
 
 set(CMAKE_C_FLAGS "$ENV{CFLAGS}" CACHE STRING "C Flags")

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -1,6 +1,6 @@
 #top dir cmake project for libhackrf + tools
 
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 2.8.12)
 project (HackRF C)
 
 set(CMAKE_C_FLAGS "$ENV{CFLAGS}" CACHE STRING "C Flags")

--- a/host/hackrf-tools/CMakeLists.txt
+++ b/host/hackrf-tools/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(hackrf-tools C)
 set(PACKAGE hackrf-tools)
 include(${PROJECT_SOURCE_DIR}/../cmake/set_release.cmake)

--- a/host/hackrf-tools/CMakeLists.txt
+++ b/host/hackrf-tools/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1.3)
 project(hackrf-tools C)
 set(PACKAGE hackrf-tools)
 include(${PROJECT_SOURCE_DIR}/../cmake/set_release.cmake)

--- a/host/libhackrf/CMakeLists.txt
+++ b/host/libhackrf/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1.3)
 project(libhackrf C)
 set(MAJOR_VERSION 0)
 set(MINOR_VERSION 8)

--- a/host/libhackrf/CMakeLists.txt
+++ b/host/libhackrf/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(libhackrf C)
 set(MAJOR_VERSION 0)
 set(MINOR_VERSION 8)


### PR DESCRIPTION
To remove the CMAKE build [deprecation warning](https://github.com/greatscottgadgets/hackrf/issues/831), update the minimum required version.