### PR TITLE
Revert "Reduce firmware USB transfer size from 16KB to 8KB."

### DIFF
--- a/firmware/hackrf_usb/usb_api_transceiver.c
+++ b/firmware/hackrf_usb/usb_api_transceiver.c
@@ -47,7 +47,7 @@
 #include "usb_endpoint.h"
 #include "usb_api_sweep.h"
 
-#define USB_TRANSFER_SIZE 0x2000
+#define USB_TRANSFER_SIZE 0x4000
 
 typedef struct {
 	uint32_t freq_mhz;
@@ -453,8 +453,7 @@ void tx_mode(uint32_t seq)
 			baseband_streaming_enable(&sgpio_config);
 			started = true;
 		}
-		if ((usb_count - m0_state.m0_count) <=
-		    (USB_BULK_BUFFER_SIZE - USB_TRANSFER_SIZE)) {
+		if ((usb_count - m0_state.m0_count) <= USB_TRANSFER_SIZE) {
 			usb_transfer_schedule_block(
 				&usb_endpoint_bulk_out,
 				&usb_bulk_buffer[usb_count & USB_BULK_BUFFER_MASK],


### PR DESCRIPTION
This reverts PR #1203, which introduced bug #1363.

The problem is as summarised [here](https://github.com/greatscottgadgets/hackrf/pull/1203#issuecomment-1848791434):

> The 32KB sample buffer straddles a block boundary such that each 16KB half-buffer is in a separate SRAM block which has its own independent AHB bus connection. With 16KB transfers, the M0 and the USB peripheral were always accessing different blocks. This change to 8KB transfers allowed the USB peripheral to start reading from the first 8KB of a 16KB half-buffer while the M0 core was still writing to the second 8KB. The contention caused by having two bus masters accessing the same SRAM block added intermittent latency, causing the M0 to sometimes miss its SGPIO timing deadlines.

Reverting this PR will eliminate the glitches, but will also cause a regression to host throughput.

We have a plan for future improvement as set out [here](https://github.com/greatscottgadgets/hackrf/issues/1363#issuecomment-1850452973):

> There is enough space in `ram_local1` (which stores the M4 text section) to add a 32 KiB or 48 KiB USB buffer separate from the M0/SGPIO buffer. Instead of having USB operations read and write directly from/to the SGPIO buffer, we can have DMA shuttle data between the SGPIO buffer and this new USB buffer. DMA transfers should complete very quickly, long before the M0 is done with the other half of the SGPIO buffer. USB reads and writes would contend only with M4 instruction reads, never with the M0.

Until this new scheme is implemented however, we should go ahead and revert the previous change.