### PR TITLE
Update documentation link in issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/technical-support.yml
+++ b/.github/ISSUE_TEMPLATE/technical-support.yml
@@ -11,7 +11,7 @@ body:
   - type: dropdown
     id: troubleshooting-documentation
     attributes: 
-      label: Have you read the HackRF [troubleshooting documentation](https://hackrf.readthedocs.io/en/latest/troubleshooting.html)?
+      label: Have you read the HackRF [documentation](https://hackrf.readthedocs.io/en/latest/)?
       options:
         - "no"
         - "yes"        


### PR DESCRIPTION
The technical support issue template was pointing at a specific "troubleshooting" page that no longer exists in the documentation.

Pointed it to the top level of the documentation instead.