### PR TITLE
doc: markdown heading

### DIFF
--- a/docs/source/list_of_hardware_revisions.rst
+++ b/docs/source/list_of_hardware_revisions.rst
@@ -33,7 +33,7 @@ HackRF One r9
 MAX2837 was replaced by MAX2839. Si5351C was replaced by Si5351A with additional clock distribution. A series diode was added to the antenna port power supply. Manufacturing year: 2023
 
 HackRF One r10
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 This revision is based on r8, reverting most of the changes made in r9. A series diode was added to the antenna port power supply. Manufacturing year: 2024
 


### PR DESCRIPTION
The previous markdown was not valid and yielded the following warning:

```sh
⬛make html
Running Sphinx v5.3.0
WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
making output directory... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 34 source files that are out of date
updating environment: [new config] 34 added, 0 changed, 0 removed
reading sources... [100%] virtual_machines
hackrf/docs/source/list_of_hardware_revisions.rst:36: WARNING: Title underline too short.

HackRF One r10
~~~~~~~~~~~~~
hackrf/docs/source/list_of_hardware_revisions.rst:36: WARNING: Title underline too short.

HackRF One r10
~~~~~~~~~~~~~
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] virtual_machines
generating indices... genindex done
writing additional pages... search done
copying images... [100%] ../images/noisereducingcablescreenshot.jpeg
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 3 warnings.

The HTML pages are in build/html.
```

Congratulations on double digits.