### PR TITLE
CI: Use special action to install & cache GNU Arm toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,16 +144,18 @@ jobs:
       with:
         submodules: true
 
+    - name: Install Arm GNU Toolchain
+      uses: carlosperate/arm-none-eabi-gcc-action@v1
+
     - name: Install dependencies (macOS)
       run: |
-        brew install --cask gcc-arm-embedded
         brew install dfu-util
         pip3 install PyYAML
       if: matrix.os == 'macos-latest'
 
     - name: Install dependencies (Ubuntu)
       run: |
-        sudo apt install dfu-util gcc-arm-none-eabi
+        sudo apt install dfu-util
       if: matrix.os == 'ubuntu-latest'
 
     - name: Build libopencm3


### PR DESCRIPTION
Uses [this GitHub action](https://github.com/marketplace/actions/arm-none-eabi-gcc-gnu-arm-embedded-toolchain) to install and cache the GNU Arm toolchain for firmware builds.

This should speed things up and avoid occasional failures with the Homebrew cask install on macOS runs.