### PR TITLE
docs: update github.com/mossmann urls

### DIFF
--- a/docs/source/firmware_development_setup.rst
+++ b/docs/source/firmware_development_setup.rst
@@ -4,4 +4,4 @@ Firmware Development Setup
 
 Firmware build instructions are included in the repository under firmware/README:
 
-`https://github.com/mossmann/hackrf/blob/master/firmware/README <https://github.com/mossmann/hackrf/blob/master/firmware/README>`__
+`https://github.com/greatscottgadgets/hackrf/blob/master/firmware/README <https://github.com/greatscottgadgets/hackrf/blob/master/firmware/README>`__

--- a/docs/source/installing_hackrf_software.rst
+++ b/docs/source/installing_hackrf_software.rst
@@ -76,7 +76,7 @@ Installing From Source
 Linux / OS X / \*BSD: Building HackRF Software From Source
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Acquire the source for the HackRF tools from either a `release archive <https://github.com/mossmann/hackrf/releases>`__ or git: ``git clone https://github.com/mossmann/hackrf.git``
+Acquire the source for the HackRF tools from either a `release archive <https://github.com/greatscottgadgets/hackrf/releases>`__ or git: ``git clone https://github.com/greatscottgadgets/hackrf.git``
 
 Once you have the source downloaded, the host tools can be built as follows:
 

--- a/docs/source/updating_firmware.rst
+++ b/docs/source/updating_firmware.rst
@@ -19,7 +19,7 @@ To update the firmware on a working HackRF One, use the hackrf_spiflash program:
 
 	hackrf_spiflash -w hackrf_one_usb.bin
 
-You can find the firmware binary (hackrf_one_usb.bin) in the firmware-bin directory of the latest `release package <https://github.com/mossmann/hackrf/releases/latest>`__ or you can compile your own from the `source <https://github.com/mossmann/hackrf/tree/master/firmware>`__. For Jawbreaker, use hackrf_jawbreaker_usb.bin. If you compile from source, the file will be called hackrf_usb.bin.
+You can find the firmware binary (hackrf_one_usb.bin) in the firmware-bin directory of the latest `release package <https://github.com/greatscottgadgets/hackrf/releases/latest>`__ or you can compile your own from the `source <https://github.com/greatscottgadgets/hackrf/tree/master/firmware>`__. For Jawbreaker, use hackrf_jawbreaker_usb.bin. If you compile from source, the file will be called hackrf_usb.bin.
 
 The hackrf_spiflash program is part of hackrf-tools.
 


### PR DESCRIPTION
In the installing_hackrf_software docs, under "Installing From Source", the source url still points to `git clone https://github.com/mossmann/hackrf.git` instead of `https://github.com/greatscottgadgets/hackrf.git`

Unlike the other browser links, the git url is not automatically redirected, so cloning will fail:

```
jg@buildbot:~/hackrf$ git clone https://github.com/mossman/hackrf.git
Cloning into 'hackrf'...
remote: Repository not found.
fatal: repository 'https://github.com/mossman/hackrf.git/' not found
```

While creating this patch, I also found a few more of those older urls and updated them too. One last unfixed url remains at https://hackrf.readthedocs.io/en/latest/LPC43XX_Debugging.html#lpc-link, however I could not find the intended destination so I have left it as-is.