### PR TITLE
Correct prototype of flush callback in example code.

### DIFF
--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -363,7 +363,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
  *     return 0;
  * }
  * 
- * void flush_callback(hackrf_transfer *transfer) {
+ * void flush_callback(void *ctx, int success) {
  *     pthread_mutex_lock(&mutex);
  *     pthread_cond_broadcast(&cond);
  *     pthread_mutex_unlock(&mutex);


### PR DESCRIPTION
Fixes #1439.