### PR TITLE
ci: usb hub ppps handling overhaul

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
-# Sandbox test environment for HackRF
+# Environment for HackRF HIL testing with Jenkins CI
 FROM ubuntu:22.04
 USER root
 
-# Override interactive installations and install prerequisites
+# Copy usb hub script from Jenkins' container
+COPY --from=gsg-jenkins /startup/hubs.py /startup/hubs.py
+COPY --from=gsg-jenkins /startup/.hubs /startup/.hubs
+RUN ln -s /startup/hubs.py /usr/local/bin/hubs
+
+# Override interactive installations and install software dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     build-essential \
     cmake \
+    curl \
     dfu-util \
     gcc-arm-none-eabi \
     git \
@@ -16,8 +22,18 @@ RUN apt-get update && apt-get install -y \
     python3 \
     python3-pip \
     python3-yaml \
+    usbutils \
     && rm -rf /var/lib/apt/lists/*
-RUN pip3 install git+https://github.com/CapableRobot/CapableRobot_USBHub_Driver --upgrade
+
+# Install USB hub PPPS dependencies
+RUN pip3 install python-dotenv git+https://github.com/CapableRobot/CapableRobot_USBHub_Driver --upgrade
+RUN curl -L https://github.com/mvp/uhubctl/archive/refs/tags/v2.5.0.tar.gz > uhubctl-2.5.0.tar.gz \
+    && mkdir uhubctl-2.5.0 \
+    && tar -xvzf uhubctl-2.5.0.tar.gz -C uhubctl-2.5.0 --strip-components 1 \
+    && rm uhubctl-2.5.0.tar.gz \
+    && cd uhubctl-2.5.0 \
+    && make \
+    && make install
 
 # Inform Docker that the container is listening on port 8080 at runtime
 EXPOSE 8080

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         dockerfile {
-            args '--group-add=46 --device-cgroup-rule="c 189:* rmw" -v /dev/bus/usb:/dev/bus/usb'
+            args '--group-add=20 --group-add=46 --device-cgroup-rule="c 189:* rmw" --device-cgroup-rule="c 166:* rmw" -v /dev/bus/usb:/dev/bus/usb -e TESTER=0000000000000000325866e629a25623 -e EUT=RunningFromRAM'
         }
     }
     stages {
@@ -17,7 +17,7 @@ pipeline {
         }
         stage('Test') {
             steps {
-                sh './ci-scripts/configure-hubs.sh --off'
+                sh 'hubs all off'
                 retry(3) {
                     sh './ci-scripts/test-host.sh'
                 }
@@ -32,14 +32,14 @@ pipeline {
                 retry(3) {
                     sh 'python3 ci-scripts/test-transfer.py rx'
                 }
-                sh './ci-scripts/configure-hubs.sh --off'
+                sh 'hubs all off'
                 sh 'python3 ci-scripts/test-sgpio-debug.py'
-                sh './ci-scripts/configure-hubs.sh --reset'
             }
         }
     }
     post {
         always {
+            sh 'hubs all reset'
             cleanWs(cleanWhenNotBuilt: false,
                     deleteDirs: true,
                     disableDeferredWipeout: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     stages {
         stage('Build Docker Image') {
             steps {
-                sh 'docker build -t hackrf $GIT_URL'
+                sh 'docker build -t hackrf https://github.com/greatscottgadgets/hackrf.git'
             }
         }
         stage('Test Suite') {

--- a/ci-scripts/configure-hubs.sh
+++ b/ci-scripts/configure-hubs.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-usbhub --disable-i2c --hub D9D1 power state --port 1,2,3,4 $1
-usbhub --disable-i2c --hub 624C power state --port 1,2,3,4 $1

--- a/ci-scripts/test-firmware-program.sh
+++ b/ci-scripts/test-firmware-program.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-usbhub --disable-i2c --hub D9D1 power state --port 2 --reset
+hubs hackrf_dfu reset
 sleep 1s
 dfu-util --device 1fc9:000c --alt 0 --download firmware/hackrf_usb/build/hackrf_usb.dfu
 sleep 1s

--- a/ci-scripts/test-host.sh
+++ b/ci-scripts/test-host.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-usbhub --disable-i2c --hub D9D1 power state --port 2 --reset
+hubs hackrf_dfu reset
 sleep 1s
 host/build/hackrf-tools/src/hackrf_info
 EXIT_CODE="$?"

--- a/ci-scripts/test-transfer.py
+++ b/ci-scripts/test-transfer.py
@@ -2,9 +2,10 @@
 import subprocess
 import time
 import sys
+from os import environ
 
-EUT     = "RunningFromRAM"
-TESTER  = "0000000000000000325866e629a25623"
+EUT     = environ.get('EUT')
+TESTER  = environ.get('TESTER')
 PASS, FAIL = range(2)
 
 
@@ -87,8 +88,7 @@ def check_signal(freq, bins):
 
 def main():
     write_bytes()
-    tester_hub_on = subprocess.Popen(["usbhub", "--disable-i2c", "--hub", "624C",
-                                      "power", "state", "--port", "2", "--reset"])
+    tester_hub_on = subprocess.Popen(["hubs", "hackrf", "reset"])
     tester_hub_on.wait()
     time.sleep(1)
     eut_clkout_on       = subprocess.Popen(["host/build/hackrf-tools/src/hackrf_clock",


### PR DESCRIPTION
- Moves usb hub port->device mapping responsibility to the Jenkins test server.
- Builds docker image from `master:latest` to prevent malicious changes to the Dockerfile from being run on PR.

Note: [0212bf6](https://github.com/greatscottgadgets/hackrf/pull/1466/commits/0212bf625a199d0b0bb713bc408f884426f68908) is expected to [fail the Jenkins build](https://jenkins.greatscottgadgets.com/job/greatscottgadgets-organization/job/hackrf/job/PR-1466/4/console) until it's [replayed with `$GIT_URL` pointing to my fork](https://jenkins.greatscottgadgets.com/job/greatscottgadgets-organization/job/hackrf/job/PR-1466/5/console) since `gsg:master:latest` doesn't yet have the updated Dockerfile required for running the new hub commands.