### PR TITLE
Implement RAW_IO with WinUSB

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -728,6 +728,13 @@ static int hackrf_open_setup(libusb_device_handle* usb_device, hackrf_device** d
 		return HACKRF_ERROR_NO_MEM;
 	}
 
+#if LIBUSB_API_VERSION >= 0x0100010C
+	// WinUSB: Use RAW_IO to improve throughput on RX
+	if (libusb_endpoint_supports_raw_io(usb_device, RX_ENDPOINT_ADDRESS) == 1) {
+		libusb_endpoint_set_raw_io(usb_device, RX_ENDPOINT_ADDRESS, 1);
+	}
+#endif
+
 	lib_device->usb_device = usb_device;
 	lib_device->transfers = NULL;
 	lib_device->callback = NULL;


### PR DESCRIPTION
At the request of @martinling, here's a draft PR that implements RAW_IO on Windows, using libusb/libusb#1512. The change checks if RAW_IO is available, and if it is, it turns it on for the `RX_ENDPOINT_ADDRESS`. I've made it silently ignore the result of `libusb_endpoint_set_raw_io`, since in the unlikely event of the call not working, I'd think we should continue on anyway.

This change fixes sample drops on problematic Windows machines. I've marked the PR a draft because this change will require `#if LIBUSB_API_VERSION >= 0x0100010B ... #endif` to prevent issues when building with older versions of LibUSB. The problem is:

- The change isn't actually merged into LibUSB yet (hopefully it is soon!)
- `LIBUSB_API_VERSION` has not been bumped yet. It's still sitting at 0x0100010A, so there's no good way to detect the presence of this function

While we wait for upstream devs, let me know if you'd like to see any changes to this!