### PR TITLE
Handle CTRL+BREAK signals hackrf-tools on Windows

### DIFF
--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -415,7 +415,7 @@ static hackrf_device* device = NULL;
 #ifdef _MSC_VER
 BOOL WINAPI sighandler(int signum)
 {
-	if (CTRL_C_EVENT == signum) {
+	if (CTRL_C_EVENT == signum || CTRL_BREAK_EVENT == signum) {
 		fprintf(stderr, "Caught signal %d\n", signum);
 		do_exit = true;
 		return TRUE;

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -704,7 +704,7 @@ static hackrf_device* device = NULL;
 #ifdef _WIN32
 BOOL WINAPI sighandler(int signum)
 {
-	if (CTRL_C_EVENT == signum) {
+	if (CTRL_C_EVENT == signum || CTRL_BREAK_EVENT == signum) {
 		interrupted = true;
 		fprintf(stderr, "Caught signal %d\n", signum);
 		stop_main_loop();


### PR DESCRIPTION
When running `hackrf_transfer` as a subprocess under Windows we've found that it's exceptionally hard to stop the process.
It turns out to be much easier to send a `CTRL_BREAK_EVENT` signal to a process than a `CTRL_C_EVENT`.