### PR TITLE
SGPIO deadline check

### DIFF
--- a/firmware/hackrf_usb/sgpio_m0.s
+++ b/firmware/hackrf_usb/sgpio_m0.s
@@ -430,12 +430,26 @@ as follows:
 
 Routine:                Uses conditional branches to:
 
-idle                    tx_loop, wait_loop
+idle                    tx_loop
+                        wait_loop
+
 tx_zeros                tx_loop
+
 checked_rollback        idle
-tx_loop                 tx_zeros, checked_rollback, rx_loop, wait_loop
-wait_loop               rx_loop, tx_loop
-rx_loop                 rx_shortfall, checked_rollback, tx_loop, wait_loop
+
+tx_loop                 tx_zeros
+                        checked_rollback
+                        wait_loop
+                        rx_loop
+
+wait_loop               tx_loop
+                        rx_loop
+
+rx_loop                 checked_rollback
+                        tx_loop
+                        wait_loop
+                        rx_shortfall
+
 rx_shortfall            rx_loop
 
 If any of these routines are reordered, or made longer, you may get an error

--- a/host/hackrf-tools/src/hackrf_debug.c
+++ b/host/hackrf-tools/src/hackrf_debug.c
@@ -428,7 +428,11 @@ static const char* mode_name(uint32_t mode)
 
 static const char* error_name(uint32_t error)
 {
-	const char* error_names[] = {"NONE", "RX_TIMEOUT", "TX_TIMEOUT"};
+	const char* error_names[] = {
+		"NONE",
+		"RX_TIMEOUT",
+		"TX_TIMEOUT",
+		"MISSED_DEADLINE"};
 	const uint32_t num_errors = sizeof(error_names) / sizeof(error_names[0]);
 	if (error < num_errors) {
 		return error_names[error];

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -975,7 +975,7 @@ typedef struct {
 	uint32_t threshold;
 	/** Mode which will be switched to when threshold is reached. Possible values are the same as in @ref hackrf_m0_state.requested_mode */
 	uint32_t next_mode;
-	/** Error, if any, that caused the M0 to revert to IDLE mode. Possible values are 0 (NONE), 1 (RX_TIMEOUT) and 2(TX_TIMEOUT)*/
+	/** Error, if any, that caused the M0 to revert to IDLE mode. Possible values are 0 (NONE), 1 (RX_TIMEOUT) 2 (TX_TIMEOUT) or 3 (MISSED_DEADLINE) */
 	uint32_t error;
 } hackrf_m0_state;
 


### PR DESCRIPTION
Checks whether the M0 core missed its deadline: i.e. if the next SGPIO interrupt already occurred by the time it finished processing the last one.

If so, the M0 returns to the idle mode with an error code in the M0 state. This should cause the host tools to time out, at which point the error can be checked with `hackrf_debug -S`.