### PR TITLE
Add AGM CPLD to portapack detection routine

### DIFF
--- a/firmware/common/portapack.c
+++ b/firmware/common/portapack.c
@@ -614,7 +614,11 @@ static uint32_t jtag_pp_idcode(void)
 
 static bool portapack_detect(void)
 {
-	return jtag_pp_idcode() == 0x020A50DD;
+	const uint32_t idcode = jtag_pp_idcode();
+
+	/* 0x020A50DD => Altera 5M40ZE64C5N
+	   0x00025610 => AGM Microelectronics AG256SL100 */
+	return idcode == 0x020A50DD || idcode == 0x00025610;
 }
 
 static const portapack_t portapack_instance = {};


### PR DESCRIPTION
This pull request adds the AGM Microelectronics AG256SL100 to the portapack detection routine.

Almost all new portapacks are now made with the AGM CPLD. Without the ability to detect them in the stock hackrf firmware, users will just see a black screen and might think there is a defect as long as they didn't replace the firmware. So this should reduce user confusion and might even reduce support requests on both sides.

In the portapack firmware this fix is already injected into the "hackrf mode", but our compilation is somewhat messy now (can't just use your CMakeLists.txt).