### PR TITLE
updated minimum required cmake version to 3.16

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -20,7 +20,7 @@
 
 # Top directory CMake project for HackRF firmware
 
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_TOOLCHAIN_FILE toolchain-arm-cortex-m.cmake)
 
 project (hackrf_firmware_all C)

--- a/firmware/blinky/CMakeLists.txt
+++ b/firmware/blinky/CMakeLists.txt
@@ -19,7 +19,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_TOOLCHAIN_FILE ../toolchain-arm-cortex-m.cmake)
 
 project(blinky C)

--- a/firmware/hackrf_usb/CMakeLists.txt
+++ b/firmware/hackrf_usb/CMakeLists.txt
@@ -18,7 +18,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_TOOLCHAIN_FILE ../toolchain-arm-cortex-m.cmake)
 
 project(hackrf_usb C)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -1,6 +1,6 @@
 #top dir cmake project for libhackrf + tools
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.16)
 project (HackRF C)
 
 set(CMAKE_C_FLAGS "$ENV{CFLAGS}" CACHE STRING "C Flags")

--- a/host/hackrf-tools/CMakeLists.txt
+++ b/host/hackrf-tools/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.16)
 project(hackrf-tools C)
 set(PACKAGE hackrf-tools)
 include(${PROJECT_SOURCE_DIR}/../cmake/set_release.cmake)

--- a/host/libhackrf/CMakeLists.txt
+++ b/host/libhackrf/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.16)
 project(libhackrf C)
 set(MAJOR_VERSION 0)
 set(MINOR_VERSION 9)


### PR DESCRIPTION
Latest cmake versions are giving a warning on CMakeLists files that are using a required version under 3.5.

That PR is fixing the warning by requiring a minimum version of 3.16 anywhere it was checked. I choosed 3.16 as it's the one used in a lots of other open source projects, and it's not too recent. 

As an example, we checked that Ubuntu latest stable is using a least 3.22, and Ubuntu noble based build container is having cmake version 3.28.3

'firmware' cmake warnings:
```
CMake Deprecation Warning at hackrf/firmware/CMakeLists.txt:23 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of CMake.
  Update the VERSION argument <min> value or use a ...<max> suffix to tell CMake that the project does not need compatibility with older versions.
CMake Deprecation Warning at hackrf/firmware/blinky/CMakeLists.txt:22 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of CMake.
  Update the VERSION argument <min> value or use a ...<max> suffix to tell CMake that the project does not need compatibility with older versions.
CMake Deprecation Warning at hackrf/firmware/hackrf_usb/CMakeLists.txt:21 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of CMake.
  Update the VERSION argument <min> value or use a ...<max> suffix to tell CMake that the project does not need compatibility with older versions.
```
'host' cmake warnings:
```
CMake Deprecation Warning at CMakeLists.txt:3 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of CMake.
  Update the VERSION argument <min> value or use a ...<max> suffix to tell CMake that the project does not need compatibility with older versions.
CMake Deprecation Warning at libhackrf/CMakeLists.txt:24 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of CMake.
  Update the VERSION argument <min> value or use a ...<max> suffix to tell CMake that the project does not need compatibility with older versions.
CMake Deprecation Warning at hackrf-tools/CMakeLists.txt:24 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of CMake.
  Update the VERSION argument <min> value or use a ...<max> suffix to tell CMake that the project does not need compatibility with older versions.
  ```