### PR TITLE
fix compilation warnings

### DIFF
--- a/firmware/common/usb.c
+++ b/firmware/common/usb.c
@@ -29,8 +29,8 @@
 #include "usb_standard_request.h"
 
 // avoid multiple #define declarations
-#ifndef LPC43XX_M4 
-#define LPC43XX_M4
+#ifndef LPC43XX_M4
+	#define LPC43XX_M4
 #endif
 
 #include <libopencm3/lpc43xx/creg.h>

--- a/firmware/common/usb.c
+++ b/firmware/common/usb.c
@@ -28,11 +28,6 @@
 #include "usb_queue.h"
 #include "usb_standard_request.h"
 
-// avoid multiple #define declarations
-#ifndef LPC43XX_M4
-	#define LPC43XX_M4
-#endif
-
 #include <libopencm3/lpc43xx/creg.h>
 #include <libopencm3/lpc43xx/m4/nvic.h>
 #include <libopencm3/lpc43xx/rgu.h>

--- a/firmware/common/usb.c
+++ b/firmware/common/usb.c
@@ -28,6 +28,11 @@
 #include "usb_queue.h"
 #include "usb_standard_request.h"
 
+// avoid multiple #define declarations
+#ifndef LPC43XX_M4 
+#define LPC43XX_M4
+#endif
+
 #include <libopencm3/lpc43xx/creg.h>
 #include <libopencm3/lpc43xx/m4/nvic.h>
 #include <libopencm3/lpc43xx/rgu.h>
@@ -89,7 +94,7 @@ static void usb_clear_pending_interrupts(const uint32_t mask)
 	USB0_ENDPTCOMPLETE = USB0_ENDPTCOMPLETE & mask;
 }
 
-static void usb_clear_all_pending_interrupts()
+static void usb_clear_all_pending_interrupts(void)
 {
 	usb_clear_pending_interrupts(0xFFFFFFFF);
 }
@@ -122,7 +127,7 @@ static void usb_flush_primed_endpoints(const uint32_t mask)
 	usb_wait_for_endpoint_flushing_to_finish(mask);
 }
 
-static void usb_flush_all_primed_endpoints()
+static void usb_flush_all_primed_endpoints(void)
 {
 	usb_flush_primed_endpoints(0xFFFFFFFF);
 }
@@ -315,22 +320,22 @@ void usb_endpoint_reset_data_toggle(const usb_endpoint_t* const endpoint)
 	}
 }
 
-static void usb_controller_run()
+static void usb_controller_run(void)
 {
 	USB0_USBCMD_D |= USB0_USBCMD_D_RS;
 }
 
-static void usb_controller_stop()
+static void usb_controller_stop(void)
 {
 	USB0_USBCMD_D &= ~USB0_USBCMD_D_RS;
 }
 
-static uint_fast8_t usb_controller_is_resetting()
+static uint_fast8_t usb_controller_is_resetting(void)
 {
 	return (USB0_USBCMD_D & USB0_USBCMD_D_RST) != 0;
 }
 
-static void usb_controller_set_device_mode()
+static void usb_controller_set_device_mode(void)
 {
 	// Set USB0 peripheral mode
 	USB0_USBMODE_D = USB0_USBMODE_D_CM1_0(2);
@@ -366,7 +371,7 @@ static void usb_clear_status(const uint32_t status)
 	USB0_USBSTS_D = status;
 }
 
-static uint32_t usb_get_status()
+static uint32_t usb_get_status(void)
 {
 	// Mask status flags with enabled flag interrupts.
 	const uint32_t status = USB0_USBSTS_D & USB0_USBINTR_D;
@@ -384,7 +389,7 @@ static void usb_clear_endpoint_setup_status(const uint32_t endpoint_setup_status
 	USB0_ENDPTSETUPSTAT = endpoint_setup_status;
 }
 
-static uint32_t usb_get_endpoint_setup_status()
+static uint32_t usb_get_endpoint_setup_status(void)
 {
 	return USB0_ENDPTSETUPSTAT;
 }
@@ -394,12 +399,12 @@ static void usb_clear_endpoint_complete(const uint32_t endpoint_complete)
 	USB0_ENDPTCOMPLETE = endpoint_complete;
 }
 
-static uint32_t usb_get_endpoint_complete()
+static uint32_t usb_get_endpoint_complete(void)
 {
 	return USB0_ENDPTCOMPLETE;
 }
 
-static void usb_disable_all_endpoints()
+static void usb_disable_all_endpoints(void)
 {
 	// Endpoint 0 is always enabled. TODO: So why set ENDPTCTRL0?
 	USB0_ENDPTCTRL0 &= ~(USB0_ENDPTCTRL0_RXE | USB0_ENDPTCTRL0_TXE);
@@ -427,14 +432,14 @@ void usb_set_address_deferred(const usb_device_t* const device, const uint_fast8
 	}
 }
 
-static void usb_reset_all_endpoints()
+static void usb_reset_all_endpoints(void)
 {
 	usb_disable_all_endpoints();
 	usb_clear_all_pending_interrupts();
 	usb_flush_all_primed_endpoints();
 }
 
-static void usb_controller_reset()
+static void usb_controller_reset(void)
 {
 	// TODO: Good to disable some USB interrupts to avoid priming new
 	// new endpoints before the controller is reset?
@@ -505,7 +510,7 @@ void usb_device_init(const uint_fast8_t device_ordinal, usb_device_t* const devi
 void usb_run(usb_device_t* const device)
 {
 	usb_interrupt_enable(device);
-	usb_controller_run(device);
+	usb_controller_run();
 }
 
 static void copy_setup(usb_setup_t* const dst, const volatile uint8_t* const src)
@@ -562,7 +567,7 @@ void usb_endpoint_init(const usb_endpoint_t* const endpoint)
 	usb_endpoint_enable(endpoint);
 }
 
-static void usb_check_for_setup_events()
+static void usb_check_for_setup_events(void)
 {
 	const uint32_t endptsetupstat = usb_get_endpoint_setup_status();
 	if (endptsetupstat) {
@@ -595,7 +600,7 @@ static void usb_check_for_setup_events()
 	}
 }
 
-static void usb_check_for_transfer_events()
+static void usb_check_for_transfer_events(void)
 {
 	const uint32_t endptcomplete = usb_get_endpoint_complete();
 	if (endptcomplete) {

--- a/firmware/common/usb.h
+++ b/firmware/common/usb.h
@@ -29,8 +29,8 @@
 
 #include "usb_type.h"
 
-void usb_peripheral_reset();
-void usb_phy_enable();
+void usb_peripheral_reset(void);
+void usb_phy_enable(void);
 
 void usb_device_init(const uint_fast8_t device_ordinal, usb_device_t* const device);
 

--- a/firmware/common/usb_queue.c
+++ b/firmware/common/usb_queue.c
@@ -26,6 +26,11 @@
 #include <stddef.h>
 #include <assert.h>
 
+// for __ldrex and __strex declarations
+#ifndef __ARM_ARCH_7M__
+#define __ARM_ARCH_7M__
+#endif
+
 #include <libopencm3/cm3/cortex.h>
 #include <libopencm3/cm3/sync.h>
 

--- a/firmware/common/usb_queue.c
+++ b/firmware/common/usb_queue.c
@@ -28,7 +28,7 @@
 
 // for __ldrex and __strex declarations
 #ifndef __ARM_ARCH_7M__
-#define __ARM_ARCH_7M__
+	#define __ARM_ARCH_7M__
 #endif
 
 #include <libopencm3/cm3/cortex.h>

--- a/firmware/common/usb_queue.c
+++ b/firmware/common/usb_queue.c
@@ -26,11 +26,6 @@
 #include <stddef.h>
 #include <assert.h>
 
-// for __ldrex and __strex declarations
-#ifndef __ARM_ARCH_7M__
-	#define __ARM_ARCH_7M__
-#endif
-
 #include <libopencm3/cm3/cortex.h>
 #include <libopencm3/cm3/sync.h>
 


### PR DESCRIPTION
That PR is fixing all the following warnings:
```
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:26:
~/portapack-mayhem/hackrf/firmware/common/usb.h:32:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   32 | void usb_peripheral_reset();
      | ^~~~
~/portapack-mayhem/hackrf/firmware/common/usb.h:33:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   33 | void usb_phy_enable();
      | ^~~~
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:45: warning: "NVIC_SGPIO_IRQ" redefined
   45 | #define NVIC_SGPIO_IRQ 31
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:34: note: this is the location of the previous definition
   34 | #define NVIC_SGPIO_IRQ 19
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:50: warning: "NVIC_PIN_INT4_IRQ" redefined
   50 | #define NVIC_PIN_INT4_IRQ 36
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:29: note: this is the location of the previous definition
   29 | #define NVIC_PIN_INT4_IRQ 14
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:55: warning: "NVIC_GINT1_IRQ" redefined
   55 | #define NVIC_GINT1_IRQ 41
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:28: note: this is the location of the previous definition
   28 | #define NVIC_GINT1_IRQ 13
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:56: warning: "NVIC_EVENTROUTER_IRQ" redefined
   56 | #define NVIC_EVENTROUTER_IRQ 42
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:38: note: this is the location of the previous definition
   38 | #define NVIC_EVENTROUTER_IRQ 23
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:59: warning: "NVIC_RTC_IRQ" redefined
   59 | #define NVIC_RTC_IRQ 47
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:16: note: this is the location of the previous definition
   16 | #define NVIC_RTC_IRQ 0
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:61: warning: "NVIC_C_CAN0_IRQ" redefined
   61 | #define NVIC_C_CAN0_IRQ 51
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:44: note: this is the location of the previous definition
   44 | #define NVIC_C_CAN0_IRQ 29
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:64: warning: "NVIC_IRQ_COUNT" redefined
   64 | #define NVIC_IRQ_COUNT 53
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:46: note: this is the location of the previous definition
   46 | #define NVIC_IRQ_COUNT 30
      | 
~/portapack-mayhem/hackrf/firmware/common/usb.c:70:6: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   70 | void usb_peripheral_reset()
      |      ^~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:78:6: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   78 | void usb_phy_enable()
      |      ^~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:92:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   92 | static void usb_clear_all_pending_interrupts()
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:125:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  125 | static void usb_flush_all_primed_endpoints()
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:318:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  318 | static void usb_controller_run()
      |             ^~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:323:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  323 | static void usb_controller_stop()
      |             ^~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:328:21: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  328 | static uint_fast8_t usb_controller_is_resetting()
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:333:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  333 | static void usb_controller_set_device_mode()
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:369:17: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  369 | static uint32_t usb_get_status()
      |                 ^~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:387:17: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  387 | static uint32_t usb_get_endpoint_setup_status()
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:397:17: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  397 | static uint32_t usb_get_endpoint_complete()
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:402:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  402 | static void usb_disable_all_endpoints()
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:430:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  430 | static void usb_reset_all_endpoints()
      |             ^~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:437:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  437 | static void usb_controller_reset()
      |             ^~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:565:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  565 | static void usb_check_for_setup_events()
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:598:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  598 | static void usb_check_for_transfer_events()
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb_queue.c:32:
~/portapack-mayhem/hackrf/firmware/common/usb.h:32:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   32 | void usb_peripheral_reset();
      | ^~~~
~/portapack-mayhem/hackrf/firmware/common/usb.h:33:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   33 | void usb_phy_enable();
      | ^~~~
~/portapack-mayhem/hackrf/firmware/common/usb_queue.c: In function 'allocate_transfer':
~/portapack-mayhem/hackrf/firmware/common/usb_queue.c:76:22: warning: implicit declaration of function '__ldrex' [-Wimplicit-function-declaration]
   76 |   transfer = (void*) __ldrex((uint32_t*) &queue->free_transfers);
      |                      ^~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb_queue.c:78:4: warning: implicit declaration of function '__strex' [-Wimplicit-function-declaration]
   78 |    __strex((uint32_t) transfer->next,
      |    ^~~~~~~
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb_request.c:23:
~/portapack-mayhem/hackrf/firmware/common/usb.h:32:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   32 | void usb_peripheral_reset();
      | ^~~~
~/portapack-mayhem/hackrf/firmware/common/usb.h:33:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   33 | void usb_phy_enable();
      | ^~~~
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb_standard_request.c:28:
~/portapack-mayhem/hackrf/firmware/common/usb.h:32:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   32 | void usb_peripheral_reset();
      | ^~~~
~/portapack-mayhem/hackrf/firmware/common/usb.h:33:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   33 | void usb_phy_enable();
      | ^~~~
```