### PR TITLE
Add a shim header to support locking without ldrex/strex

### DIFF
--- a/firmware/common/locking.h
+++ b/firmware/common/locking.h
@@ -26,6 +26,12 @@
 
 #include <libopencm3/cm3/sync.h>
 
+/* Primitives for implementing locking.
+ *
+ * Must always be used in a pair, with a call to load_exclusive being
+ * followed immediately or near-immediately by a call to store_exclusive().
+ * Failure to observe this rule may lead to undefined results. */
+
 // Use ldrex and strex directly if available.
 // Otherwise, disable interrupts to ensure exclusivity.
 #if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)

--- a/firmware/common/locking.h
+++ b/firmware/common/locking.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Great Scott Gadgets <info@greatscottgadgets.com>
+ *
+ * This file is part of HackRF.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __LOCKING_H__
+#define __LOCKING_H__
+
+#include <stdint.h>
+
+#include <libopencm3/cm3/sync.h>
+
+// Use ldrex and strex directly if available.
+// Otherwise, disable interrupts to ensure exclusivity.
+#if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+	#define load_exclusive  __ldrex
+	#define store_exclusive __strex
+#else
+static inline uint32_t load_exclusive(volatile uint32_t* addr)
+{
+	__disable_irq();
+	return *addr;
+}
+
+static inline uint32_t store_exclusive(uint32_t val, volatile uint32_t* addr)
+{
+	*addr = val;
+	__enable_irq();
+	return 0;
+}
+#endif
+
+#endif /* __LOCKING_H__ */

--- a/firmware/common/usb.c
+++ b/firmware/common/usb.c
@@ -29,7 +29,7 @@
 #include "usb_standard_request.h"
 
 #include <libopencm3/lpc43xx/creg.h>
-#include <libopencm3/lpc43xx/m4/nvic.h>
+#include <libopencm3/dispatch/nvic.h>
 #include <libopencm3/lpc43xx/rgu.h>
 #include <libopencm3/lpc43xx/usb.h>
 


### PR DESCRIPTION
Required to allow the USB queue code to be built for the M0.