### PR TITLE
define replacement for enable and disable irq for m0

### DIFF
--- a/firmware/common/locking.h
+++ b/firmware/common/locking.h
@@ -40,14 +40,14 @@
 #else
 static inline uint32_t load_exclusive(volatile uint32_t* addr)
 {
-	__disable_irq();
+	__asm volatile("cpsid i");
 	return *addr;
 }
 
 static inline uint32_t store_exclusive(uint32_t val, volatile uint32_t* addr)
 {
 	*addr = val;
-	__enable_irq();
+	__asm volatile("cpsie i");
 	return 0;
 }
 #endif

--- a/firmware/common/locking.h
+++ b/firmware/common/locking.h
@@ -40,14 +40,14 @@
 #else
 static inline uint32_t load_exclusive(volatile uint32_t* addr)
 {
-	__asm volatile("cpsid i");
+	__asm volatile("cpsid i" ::: "memory");
 	return *addr;
 }
 
 static inline uint32_t store_exclusive(uint32_t val, volatile uint32_t* addr)
 {
 	*addr = val;
-	__asm volatile("cpsie i");
+	__asm volatile("cpsie i" ::: "memory");
 	return 0;
 }
 #endif


### PR DESCRIPTION
Following the comment here: https://github.com/greatscottgadgets/hackrf/pull/1517#issuecomment-2549482791

We are getting undefined reference to enable/disable irq calls.

I'm providing a fix for build on m0, based on the definition that can be found in chibios.