### PR TITLE
Update section about windows binaries

### DIFF
--- a/docs/source/installing_hackrf_software.rst
+++ b/docs/source/installing_hackrf_software.rst
@@ -62,7 +62,7 @@ OS X (10.5+): MacPorts
 Windows: Binaries
 +++++++++++++++++
 
-Binaries are provided as part of the PothosSDR project, they can be downloaded `here <http://downloads.myriadrf.org/builds/PothosSDR/?C=M;O=D>`__.
+Binaries are available as build artifacts under the 'Actions'-tab on github `here <https://github.com/greatscottgadgets/hackrf/actions>`__.
 
 
 


### PR DESCRIPTION
The most current PothosSDR binary in the link is from 2021, while the build artifacts always provide the most current binary.
They also are available directly from this repository this way, instead of relying on a third party.