### PR TITLE
hackrf manpages

### DIFF
--- a/host/hackrf-tools/CMakeLists.txt
+++ b/host/hackrf-tools/CMakeLists.txt
@@ -45,6 +45,11 @@ endif()
 
 add_subdirectory(src)
 
+option(INSTALL_MANPAGES "Install man pages" OFF)
+if (INSTALL_MANPAGES)
+  add_subdirectory(man)
+endif()
+
 ########################################################################
 # Create uninstall target
 ########################################################################

--- a/host/hackrf-tools/man/CMakeLists.txt
+++ b/host/hackrf-tools/man/CMakeLists.txt
@@ -1,0 +1,11 @@
+install(FILES
+  hackrf_biast.1
+  hackrf_clock.1
+  hackrf_cpldjtag.1
+  hackrf_debug.1
+  hackrf_info.1
+  hackrf_operacake.1
+  hackrf_spiflash.1
+  hackrf_sweep.1
+  hackrf_transfer.1
+  DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)

--- a/host/hackrf-tools/man/hackrf_biast.1
+++ b/host/hackrf-tools/man/hackrf_biast.1
@@ -1,0 +1,41 @@
+.TH HACKRF_BIAST "1" "January 2023" "HackRF antenna power utility" "User Commands"
+.SH NAME
+hackrf_biast \- antenna power utility
+.SH DESCRIPTION
+hackrf_biast \- HackRF antenna power bias-T configuration utility
+Usage:
+.HP
+\fB\-h\fR, \fB\-\-help\fR: this help
+.HP
+\fB\-R\fR: Reset all bias tee settings to device default.  When combined
+with -r/-t/-o, those settings will take precedence.
+.HP
+\fB\-b\fR: <mode> : 1=Enable bias tee immediately, 0=disable immediately
+.HP
+\fB\-r\fR: <mode> : Set default bias tee power when device enters RX mode
+.HP
+\fB\-t\fR: <mode> : Set default bias tee power when device enters TX mode
+.HP
+\fB\-o\fR: <mode> : Set default bias tee power when device enters OFF mode
+.HP
+\fB\-d\fR:  <serial_number>: Specify serial number of HackRF device to configure.
+.SH EXAMPLES
+.IP
+hackrf_clock \-r 3 : prints settings for CLKOUT
+.SS "Usage:"
+.HP
+\-h, \-\-help: this help
+.IP
+hackrf_biar \-R : Resets biast setting to default.
+.HP
+The -r/-t/-o options support the following mode settings:
+.IP
+leave		do nothing when entering mode
+.IP
+on		enable bias tee when entering mode
+.IP
+off		disable bias tee when entering mode
+.SH "SEE ALSO"
+The primary source of documentation is the wiki on github:
+.P
+https://github.com/mossmann/hackrf/wiki

--- a/host/hackrf-tools/man/hackrf_clock.1
+++ b/host/hackrf-tools/man/hackrf_clock.1
@@ -1,0 +1,36 @@
+.TH HACKRF_CLOCK "1" "July 2021" "HackRF clock configuration utility" "User Commands"
+.SH NAME
+hackrf_clock \- clock configuration utility
+.SH DESCRIPTION
+hackrf_clock \- HackRF clock configuration utility
+Usage:
+.HP
+\fB\-h\fR, \fB\-\-help\fR: this help
+.HP
+\fB\-r\fR, \fB\-\-read\fR <clock_num>: read settings for clock_num
+.HP
+\fB\-a\fR, \fB\-\-all\fR: read settings for all clocks
+.HP
+\fB\-o\fR, \fB\-\-clkout\fR <clkout_enable>: enable/disable CLKOUT
+.HP
+\fB\-d\fR, \fB\-\-device\fR <serial_number>: Serial number of desired HackRF.
+.SH EXAMPLES
+.IP
+hackrf_clock \-r 3 : prints settings for CLKOUT
+.SS "Usage:"
+.HP
+\-h, \-\-help: this help
+.HP
+\-r, \-\-read <clock_num>: read settings for clock_num
+.HP
+\-a, \-\-all: read settings for all clocks
+.HP
+\-o, \-\-clkout <clkout_enable>: enable/disable CLKOUT
+.HP
+\-d, \-\-device <serial_number>: Serial number of desired HackRF.
+.IP
+hackrf_clock \-r 3 : prints settings for CLKOUT
+.SH "SEE ALSO"
+The primary source of documentation is the wiki on github:
+.P
+https://github.com/mossmann/hackrf/wiki

--- a/host/hackrf-tools/man/hackrf_cpldjtag.1
+++ b/host/hackrf-tools/man/hackrf_cpldjtag.1
@@ -1,0 +1,40 @@
+.TH "hackrf_cpldjtag" 1 "2013.07.1" HACKRF "User Commands"
+.SH NAME
+hackrf_cpldjtag \- program CPLD
+.SH DESCRIPTION
+The HackRF project started by Michael Ossmann and Jared Boone to build
+software radio peripheral using Free Software and Free Hardware
+design. Care was taken to only use electronic components with
+published documentation (no NDAs!) and to avoid software libraries
+without open source licenses.
+.LP
+Jawbreaker is the first complete HackRF platform, a wideband software radio
+transceiver with a USB interface.
+.LP
+This application lets the user configure the on-board CPLD.
+.SH SYNOPSIS
+.B  hackrf_cpldjtag -x <filename>
+.SH OPTIONS
+.IP "-x <filename>: XSVF file to be written to CPLD."
+.SH SEE ALSO
+Great Scott Gadgets HackRF web page:
+.B http://greatscottgadgets.com/hackrf/
+.LP
+Other hackrf programs:
+.sp
+hackrf_debug(1), hackrf_info(1), hackrf_spiflash(1), hackrf_transfer(1)
+.SH AUTHOR
+This manual page was written by Maitland Bottoms
+for the Debian project (but may be used by others).
+.SH COPYRIGHT
+Copyright (c) 2013 A. Maitland Bottoms <bottoms@debian.org>
+.LP
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+.LP
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.

--- a/host/hackrf-tools/man/hackrf_debug.1
+++ b/host/hackrf-tools/man/hackrf_debug.1
@@ -1,0 +1,73 @@
+.TH HACKRF_DEBUG "1" "July 2021" "hackrf_debug " "User Commands"
+.SH NAME
+hackrf_debug \- register manipultion tool
+.SH DESCRIPTION
+.SS "Usage:"
+.HP
+\fB\-h\fR, \fB\-\-help\fR: this help
+.HP
+\fB\-n\fR, \fB\-\-register\fR <n>: set register number for read/write operations
+.HP
+\fB\-r\fR, \fB\-\-read\fR: read register specified by last \fB\-n\fR argument, or all registers
+.HP
+\fB\-w\fR, \fB\-\-write\fR <v>: write register specified by last \fB\-n\fR argument with value <v>
+.HP
+\fB\-c\fR, \fB\-\-config\fR: print SI5351C multisynth configuration information
+.HP
+\fB\-d\fR, \fB\-\-device\fR <s>: specify a particular device by serial number
+.HP
+\fB\-m\fR, \fB\-\-max2837\fR: target MAX2837
+.HP
+\fB\-s\fR, \fB\-\-si5351c\fR: target SI5351C
+.HP
+\fB\-f\fR, \fB\-\-rffc5072\fR: target RFFC5072
+.HP
+\fB\-u\fR, \fB\-\-ui\fR <1/0>: enable/disable UI
+.SH EXAMPLES
+.TP
+hackrf_debug \-\-si5351c \-n 0 \-r
+# reads from si5351c register 0
+.TP
+hackrf_debug \-\-si5351c \-c
+# displays si5351c multisynth configuration
+.TP
+hackrf_debug \-\-rffc5072 \-r
+# reads all rffc5072 registers
+.IP
+hackrf_debug \-\-max2837 \-n 10 \-w 22 # writes max2837 register 10 with 22 decimal
+.SS "Usage:"
+.HP
+\-h, \-\-help: this help
+.HP
+\-n, \-\-register <n>: set register number for read/write operations
+.HP
+\-r, \-\-read: read register specified by last \-n argument, or all registers
+.HP
+\-w, \-\-write <v>: write register specified by last \-n argument with value <v>
+.HP
+\-c, \-\-config: print SI5351C multisynth configuration information
+.HP
+\-d, \-\-device <s>: specify a particular device by serial number
+.HP
+\-m, \-\-max2837: target MAX2837
+.HP
+\-s, \-\-si5351c: target SI5351C
+.HP
+\-f, \-\-rffc5072: target RFFC5072
+.HP
+\-u, \-\-ui <1/0>: enable/disable UI
+.TP
+hackrf_debug \-\-si5351c \-n 0 \-r
+# reads from si5351c register 0
+.TP
+hackrf_debug \-\-si5351c \-c
+# displays si5351c multisynth configuration
+.TP
+hackrf_debug \-\-rffc5072 \-r
+# reads all rffc5072 registers
+.IP
+hackrf_debug \-\-max2837 \-n 10 \-w 22 # writes max2837 register 10 with 22 decimal
+.SH "SEE ALSO"
+The primary source of documentation is the wiki on github:
+
+https://github.com/mossmann/hackrf/wiki

--- a/host/hackrf-tools/man/hackrf_info.1
+++ b/host/hackrf-tools/man/hackrf_info.1
@@ -1,0 +1,41 @@
+.TH "hackrf_info" 1 "2013.07.1" HACKRF "User Commands"
+.SH NAME
+hackrf_info \- probe device and show configuration
+.SH DESCRIPTION
+The HackRF project started by Michael Ossmann and Jared Boone to build
+software radio peripheral using Free Software and Free Hardware
+design. Care was taken to only use electronic components with
+published documentation (no NDAs!) and to avoid software libraries
+without open source licenses.
+.LP
+Jawbreaker is the first complete HackRF platform, a wideband software radio
+transceiver with a USB interface.
+.LP
+This application lets the user probe the device and show configuration.
+.SH SYNOPSIS
+.B  hackrf_info
+.SH OPTIONS
+.IP none
+.SH SEE ALSO
+Great Scott Gadgets HackRF web page:
+.B http://greatscottgadgets.com/hackrf/
+.LP
+Other hackrf programs:
+.sp
+hackrf_cpldjtag(1), hackrf_debug(1), hackrf_info(1), hackrf_spiflash(1), hackrf_transfer(1)
+
+.SH AUTHOR
+This manual page was written by Maitland Bottoms
+for the Debian project (but may be used by others).
+.SH COPYRIGHT
+Copyright (c) 2013 A. Maitland Bottoms <bottoms@debian.org>
+.LP
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+.LP
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.

--- a/host/hackrf-tools/man/hackrf_operacake.1
+++ b/host/hackrf-tools/man/hackrf_operacake.1
@@ -1,0 +1,42 @@
+.TH HACKRF_OPERACAKE "1" "July 2021" "hackrf_operacake " "User Commands"
+.SH NAME
+hackrf_operacake \- control of operacake board via hackrf
+.SH DESCRIPTION
+.SS "Usage:"
+.HP
+\fB\-h\fR, \fB\-\-help\fR: this help
+.HP
+\fB\-d\fR, \fB\-\-device\fR <n>: specify a particular device by serial number
+.HP
+\fB\-o\fR, \fB\-\-address\fR <n>: specify a particular operacake by address [default: 0x00]
+.HP
+\fB\-a\fR <n>: set port A connection
+.HP
+\fB\-b\fR <n>: set port B connection
+.HP
+\fB\-f\fR <min:max:port>: automatically assign <port> for range <min:max> in MHz
+.HP
+\fB\-l\fR, \fB\-\-list\fR: list available operacake boards
+.HP
+\fB\-g\fR, \fB\-\-gpio_test\fR: test GPIO functionality of an opera cake
+.SS "Usage:"
+.HP
+\fB\-h\fR, \fB\-\-help\fR: this help
+.HP
+\fB\-d\fR, \fB\-\-device\fR <n>: specify a particular device by serial number
+.HP
+\fB\-o\fR, \fB\-\-address\fR <n>: specify a particular operacake by address [default: 0x00]
+.HP
+\fB\-a\fR <n>: set port A connection
+.HP
+\fB\-b\fR <n>: set port B connection
+.HP
+\fB\-f\fR <min:max:port>: automatically assign <port> for range <min:max> in MHz
+.HP
+\fB\-l\fR, \fB\-\-list\fR: list available operacake boards
+.HP
+\fB\-g\fR, \fB\-\-gpio_test\fR: test GPIO functionality of an opera cake
+.SH "SEE ALSO"
+The primary source of documentation is the wiki on github:
+
+https://github.com/mossmann/hackrf/wiki

--- a/host/hackrf-tools/man/hackrf_spiflash.1
+++ b/host/hackrf-tools/man/hackrf_spiflash.1
@@ -1,0 +1,43 @@
+.TH "hackrf_spiflash" 1 "2013.07.1" HACKRF "User Commands"
+.SH NAME
+hackrf_spiflash \- program Flash
+.SH DESCRIPTION
+The HackRF project started by Michael Ossmann and Jared Boone to build
+software radio peripheral using Free Software and Free Hardware
+design. Care was taken to only use electronic components with
+published documentation (no NDAs!) and to avoid software libraries
+without open source licenses.
+.LP
+Jawbreaker is the first complete HackRF platform, a wideband software radio
+transceiver with a USB interface.
+.LP
+This application lets the user configure the on-board Flash.
+.SH SYNOPSIS
+.B  hackrf_spiflash [OPTIONS]
+.SH OPTIONS
+.IP "-a, --address <n>: starting address (default: 0)"
+.IP "-l, --length <n>: number of bytes to read (default: 0)"
+.IP "-r <filename>: Read data into file."
+.IP "-w <filename>: Write data from file."
+.SH SEE ALSO
+Great Scott Gadgets HackRF web page:
+.B http://greatscottgadgets.com/hackrf/
+.LP
+Other hackrf programs:
+.sp
+hackrf_cpldjtag(1), hackrf_debug(1), hackrf_info(1), hackrf_transfer(1)
+.SH AUTHOR
+This manual page was written by Maitland Bottoms
+for the Debian project (but may be used by others).
+.SH COPYRIGHT
+Copyright (c) 2013 A. Maitland Bottoms <bottoms@debian.org>
+.LP
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+.LP
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.

--- a/host/hackrf-tools/man/hackrf_sweep.1
+++ b/host/hackrf-tools/man/hackrf_sweep.1
@@ -1,0 +1,47 @@
+.TH HACKRF_SWEEP "1" "July 2021" "hackrf_sweep" "User Commands"
+.SH NAME
+hackrf_sweep \- control frequency sweep of hackrf
+.SH DESCRIPTION
+hackrf_sweep
+Usage:
+.IP
+[\-h] # this help
+[\-d serial_number] # Serial number of desired HackRF
+[\-a amp_enable] # RX RF amplifier 1=Enable, 0=Disable
+[\-f freq_min:freq_max] # minimum and maximum frequencies in MHz
+[\-p antenna_enable] # Antenna port power, 1=Enable, 0=Disable
+[\-l gain_db] # RX LNA (IF) gain, 0\-40dB, 8dB steps
+[\-g gain_db] # RX VGA (baseband) gain, 0\-62dB, 2dB steps
+[\-n num_samples] # Number of samples per frequency, 8192\-4294967296
+[\-w bin_width] # FFT bin width (frequency resolution) in Hz
+[\-1] # one shot mode
+[\-N num_sweeps] # Number of sweeps to perform
+[\-B] # binary output
+[\-I] # binary inverse FFT output
+\fB\-r\fR filename # output file
+.SS "Output fields:"
+.IP
+date, time, hz_low, hz_high, hz_bin_width, num_samples, dB, dB, . . .
+.SS "Usage:"
+.IP
+[\-h] # this help
+[\-d serial_number] # Serial number of desired HackRF
+[\-a amp_enable] # RX RF amplifier 1=Enable, 0=Disable
+[\-f freq_min:freq_max] # minimum and maximum frequencies in MHz
+[\-p antenna_enable] # Antenna port power, 1=Enable, 0=Disable
+[\-l gain_db] # RX LNA (IF) gain, 0\-40dB, 8dB steps
+[\-g gain_db] # RX VGA (baseband) gain, 0\-62dB, 2dB steps
+[\-n num_samples] # Number of samples per frequency, 8192\-4294967296
+[\-w bin_width] # FFT bin width (frequency resolution) in Hz
+[\-1] # one shot mode
+[\-N num_sweeps] # Number of sweeps to perform
+[\-B] # binary output
+[\-I] # binary inverse FFT output
+\fB\-r\fR filename # output file
+.SS "Output fields:"
+.IP
+date, time, hz_low, hz_high, hz_bin_width, num_samples, dB, dB, . . .
+.SH "SEE ALSO"
+The primary source of documentation is the wiki on github:
+
+https://github.com/mossmann/hackrf/wiki

--- a/host/hackrf-tools/man/hackrf_transfer.1
+++ b/host/hackrf-tools/man/hackrf_transfer.1
@@ -1,0 +1,55 @@
+.TH "hackrf_transfer" 1 "2013.07.1" HACKRF "User Commands"
+.SH NAME
+hackrf_transfer \- file based transmit and receive sdr
+.SH DESCRIPTION
+The HackRF project started by Michael Ossmann and Jared Boone to build
+software radio peripheral using Free Software and Free Hardware
+design. Care was taken to only use electronic components with
+published documentation (no NDAs!) and to avoid software libraries
+without open source licenses.
+.LP
+Jawbreaker is the first complete HackRF platform, a wideband software radio
+transceiver with a USB interface.
+.LP
+This application lets the user receive data from RF and transmit
+data to RF.
+.SH SYNOPSIS
+.B  hackrf_transfer [OPTIONS]
+.SH OPTIONS
+.IP "-r <filename> # Receive data into file."
+.IP "-t <filename> # Transmit data from file."
+.IP "-w # Receive data into file with WAV header and automatic name."
+.IP " # This is for SDR# compatibility and may not work with other software."
+.IP "[-f set_freq_hz] # Set Freq in Hz"
+.IP "[-a set_amp] # Set Amp 1=Enable, 0=Disable."
+.IP "[-l gain_db] # Set lna gain, 0-40dB, 8dB steps"
+.IP "[-i gain_db] # Set vga(if) gain, 0-62dB, 2dB steps"
+.IP "[-x gain_db] # Set TX vga gain, 0-47dB, 1dB steps"
+.IP "[-s sample_rate_hz] # Set sample rate in Hz (8/10/12.5/16/20MHz)"
+.IP "[-n num_samples] # Number of samples to transfer (default is unlimited)."
+.IP "[-b baseband_filter_bw_hz] # Set baseband filter bandwidth in MHz."
+ Possible values:
+ 1.75/2.5/3.5/5/5.5/6/7/8/9/10/12/14/15/20/24/28MHz,
+ default < sample_rate_hz.
+.SH SEE ALSO
+Great Scott Gadgets HackRF web page:
+.B http://greatscottgadgets.com/hackrf/
+.LP
+Other hackrf programs:
+.sp
+hackrf_cpldjtag(1), hackrf_debug(1), hackrf_info(1), hackrf_spiflash(1)
+.SH AUTHOR
+This manual page was written by Maitland Bottoms
+for the Debian project (but may be used by others).
+.SH COPYRIGHT
+Copyright (c) 2013 A. Maitland Bottoms <bottoms@debian.org>
+.LP
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+.LP
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.


### PR DESCRIPTION
Add man pages for hackrf-tools, along with CMake option INSTALL_MANPAGES (Off by default).