### PR TITLE
Use stdbool.h rather than our own bool definition

### DIFF
--- a/host/hackrf-tools/src/hackrf_clock.c
+++ b/host/hackrf-tools/src/hackrf_clock.c
@@ -22,16 +22,11 @@
 
 #include <hackrf.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <getopt.h>
-
-#ifndef bool
-typedef int bool;
-	#define true 1
-	#define false 0
-#endif
 
 #define CLOCK_UNDEFINED  0xFF
 #define REGISTER_INVALID 32767

--- a/host/hackrf-tools/src/hackrf_debug.c
+++ b/host/hackrf-tools/src/hackrf_debug.c
@@ -24,16 +24,11 @@
 
 #include <hackrf.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <getopt.h>
-
-#ifndef bool
-typedef int bool;
-	#define true 1
-	#define false 0
-#endif
 
 #define REGISTER_INVALID 32767
 

--- a/host/hackrf-tools/src/hackrf_operacake.c
+++ b/host/hackrf-tools/src/hackrf_operacake.c
@@ -22,16 +22,11 @@
 
 #include <hackrf.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <getopt.h>
 #include <string.h>
-
-#ifndef bool
-typedef int bool;
-	#define true 1
-	#define false 0
-#endif
 
 #define FREQ_MIN_MHZ (0)    /*    0 MHz */
 #define FREQ_MAX_MHZ (7250) /* 7250 MHz */

--- a/host/hackrf-tools/src/hackrf_spiflash.c
+++ b/host/hackrf-tools/src/hackrf_spiflash.c
@@ -23,17 +23,12 @@
 
 #include <hackrf.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <getopt.h>
 #include <sys/types.h>
-
-#ifndef bool
-typedef int bool;
-	#define true 1
-	#define false 0
-#endif
 
 #ifdef _MSC_VER
 	#ifdef _WIN64

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -23,6 +23,7 @@
 
 #include <hackrf.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,12 +38,6 @@
 #include <inttypes.h>
 
 #define _FILE_OFFSET_BITS 64
-
-#ifndef bool
-typedef int bool;
-	#define true 1
-	#define false 0
-#endif
 
 #ifdef _WIN32
 	#define _USE_MATH_DEFINES

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -25,6 +25,7 @@
 
 #include <hackrf.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,12 +38,6 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <inttypes.h>
-
-#ifndef bool
-typedef int bool;
-	#define true 1
-	#define false 0
-#endif
 
 #ifdef _WIN32
 	#include <windows.h>

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -23,6 +23,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
 #include "hackrf.h"
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #ifndef _WIN32
@@ -37,12 +38,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 	#define strdup               _strdup
 #endif
 #include <pthread.h>
-
-#ifndef bool
-typedef int bool;
-	#define true 1
-	#define false 0
-#endif
 
 #ifdef HACKRF_BIG_ENDIAN
 	#define TO_LE(x)     __builtin_bswap32(x)


### PR DESCRIPTION
It's been 25 years since C99... I think we can depend on `stdbool.h` now.

Fixes #1588.