### PR TITLE
hackrf_transfer: align rate limits with MIN/MAX_MCU_RATE

### DIFF
--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -97,8 +97,8 @@ int gettimeofday(struct timeval* tv, void* ignored)
 #define LO_MAX_HZ       (5400000000ll)
 #define DEFAULT_LO_HZ   (1000000000ll)
 
-#define SAMPLE_RATE_MIN_HZ     (2000000)  /* 2MHz min sample rate */
-#define SAMPLE_RATE_MAX_HZ     (20000000) /* 20MHz max sample rate */
+#define SAMPLE_RATE_MIN_HZ     (200000)   /* 200kHz min sample rate */
+#define SAMPLE_RATE_MAX_HZ     (21800000) /* 21.8MHz max sample rate */
 #define DEFAULT_SAMPLE_RATE_HZ (10000000) /* 10MHz default sample rate */
 
 #define DEFAULT_BASEBAND_FILTER_BANDWIDTH (5000000) /* 5MHz default */


### PR DESCRIPTION
now that we have hardware-enforced sample rate limits, I think it'd be nice to align the checks done in hackrf_transfer with those. if worried about expanding these limits breaking older firmware, I can add an USB API check for >= 1.11.

related to #1787 but seems to have no conflicts, feel free to close if you want to add that patch there :)